### PR TITLE
feat: Nicer error outputs - no tracebacks from mkdocstrings

### DIFF
--- a/src/mkdocs_autorefs/plugin.py
+++ b/src/mkdocs_autorefs/plugin.py
@@ -95,7 +95,7 @@ class AutorefsPlugin(BasePlugin):
         Returns:
             The modified config.
         """
-        log.debug("Adding AutorefsExtension to the list")
+        log.debug(f"{__name__}: Adding AutorefsExtension to the list")
         config["markdown_extensions"].append(AutorefsExtension())
         return config
 
@@ -132,7 +132,7 @@ class AutorefsPlugin(BasePlugin):
             The same HTML. We only use this hook to map anchors to URLs.
         """
         if self.scan_toc:
-            log.debug(f"Mapping identifiers to URLs for page {page.file.src_path}")
+            log.debug(f"{__name__}: Mapping identifiers to URLs for page {page.file.src_path}")
             for item in page.toc.items:
                 self.map_urls(page.url, item)
         return html
@@ -173,14 +173,14 @@ class AutorefsPlugin(BasePlugin):
         Returns:
             Modified HTML.
         """
-        log.debug(f"Fixing references in page {page.file.src_path}")
+        log.debug(f"{__name__}: Fixing references in page {page.file.src_path}")
 
         fixed_output, unmapped = fix_refs(output, page.url, self.get_item_url)
 
         if unmapped and log.isEnabledFor(logging.WARNING):
             for ref in unmapped:
                 log.warning(
-                    f"{page.file.src_path}: Could not find cross-reference target '[{ref}]'",
+                    f"{__name__}: {page.file.src_path}: Could not find cross-reference target '[{ref}]'",
                 )
 
         return fixed_output

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -7,6 +7,7 @@ The handler collects data with [`pytkdocs`](https://github.com/pawamoy/pytkdocs)
 import json
 import os
 import sys
+import traceback
 from collections import ChainMap
 from subprocess import PIPE, Popen  # noqa: S404 (what other option, more secure that PIPE do we have? sockets?)
 from typing import Any, List, Optional
@@ -211,15 +212,13 @@ class PythonCollector(BaseCollector):
         try:
             result = json.loads(stdout)
         except json.decoder.JSONDecodeError as exception:
-            log.error(f"Error while loading JSON: {stdout}")
-            raise CollectionError(str(exception)) from exception
+            error = "\n".join(("Error while loading JSON:", stdout, traceback.format_exc()))
+            raise CollectionError(error) from exception
 
         error = result.get("error")
         if error:
-            message = f"Collection failed: {error}"
             if "traceback" in result:
-                message += f"\n{result['traceback']}"
-            log.error(message)
+                error += f"\n{result['traceback']}"
             raise CollectionError(error)
 
         for loading_error in result["loading_errors"]:


### PR DESCRIPTION
(though definitely not nicer-looking in terms of code)

# Warning output from missing autorefs

The important thing I want to address is actually a kind of regression from https://github.com/pawamoy/mkdocstrings/pull/217: now `collect()` can be called from an "implicit" operation such as generating an cross-reference, and even though errors in that operation are suppressed, the explicit `log.error()` inside `collect()` is not suppressed, so I just fold that into the exception message.

<details><summary>Output for missing reference on 0.14.0</summary>

```
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
WARNING -  mkdocstrings.plugin: handlers/overview.md: Could not find cross-reference target '[mkdocsatrings.handlers.base.BaseHandler]' 
```

</details>

<details><summary>Output for missing reference on master</summary>

```
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
ERROR   -  mkdocstrings.handlers.python: Collection failed: Importing 'mkdocsatrings.handlers.base.BaseHandler' failed, possible causes are:
- an exception happened while importing
- an element in the path does not exist
Traceback (most recent call last):
  File "/home/blaxpirit/.local/lib/py/pytkdocs/loader.py", line 238, in get_object_tree
    parent_module = importlib.import_module(parent_module_path)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'mkdocsatrings'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/blaxpirit/.local/lib/py/pytkdocs/cli.py", line 205, in main
    output = json.dumps(process_json(line))
  File "/home/blaxpirit/.local/lib/py/pytkdocs/cli.py", line 114, in process_json
    return process_config(json.loads(json_input))
  File "/home/blaxpirit/.local/lib/py/pytkdocs/cli.py", line 91, in process_config
    obj = loader.get_object_documentation(path, members)
  File "/home/blaxpirit/.local/lib/py/pytkdocs/loader.py", line 339, in get_object_documentation
    leaf = get_object_tree(dotted_path, self.new_path_syntax)
  File "/home/blaxpirit/.local/lib/py/pytkdocs/loader.py", line 241, in get_object_tree
    raise ImportError(
ImportError: Importing 'mkdocsatrings.handlers.base.BaseHandler' failed, possible causes are:
- an exception happened while importing
- an element in the path does not exist
 
WARNING -  handlers/overview.md: Could not find cross-reference target '[mkdocsatrings.handlers.base.BaseHandler]' 
```

</details>

<details><summary>Output for missing reference with this change</summary>

```
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
WARNING -  handlers/overview.md: Could not find cross-reference target '[mkdocsatrings.handlers.base.BaseHandler]' 
```

</details>

# Error output from missing autodocs

But I also want to finally tackle the issue that mkdocstrings prints a useless traceback to its own implementation whenever an error happens. Sure, normally you'd think that that is blocked on https://github.com/mkdocs/mkdocs/pull/2103 having been released, but actually we can """polyfill""" it by just raising `SystemExit`. The difference is only that MkDocs has no opportunity to print the [`"Error reading page '{}'"` message](https://github.com/mkdocs/mkdocs/blob/3c9358bb6afedb559850a640961a691d698866ba/mkdocs/commands/build.py#L182) but I polyfill that too.

<details><summary>Output for missing autodoc on 0.14.0 (same on master)</summary>

```
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
ERROR   -  mkdocstrings.handlers.python: Collection failed: No module named 'mkdocstrings.pluginz'
Traceback (most recent call last):
  File "/home/blaxpirit/.local/lib/py/pytkdocs/cli.py", line 205, in main
    output = json.dumps(process_json(line))
  File "/home/blaxpirit/.local/lib/py/pytkdocs/cli.py", line 114, in process_json
    return process_config(json.loads(json_input))
  File "/home/blaxpirit/.local/lib/py/pytkdocs/cli.py", line 91, in process_config
    obj = loader.get_object_documentation(path, members)
  File "/home/blaxpirit/.local/lib/py/pytkdocs/loader.py", line 339, in get_object_documentation
    leaf = get_object_tree(dotted_path, self.new_path_syntax)
  File "/home/blaxpirit/.local/lib/py/pytkdocs/loader.py", line 227, in get_object_tree
    parent_module = importlib.import_module(module_path)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'mkdocstrings.pluginz'
 
ERROR   -  mkdocstrings.extension: Could not collect 'mkdocstrings.pluginz' 
ERROR   -  Error reading page 'reference/plugin.md': No module named 'mkdocstrings.pluginz' 
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/blaxpirit/.local/lib/py/mkdocs/__main__.py", line 199, in <module>
    cli()
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/blaxpirit/.local/lib/py/mkdocs/__main__.py", line 139, in serve_command
    serve.serve(
  File "/home/blaxpirit/.local/lib/py/mkdocs/commands/serve.py", line 142, in serve
    config = builder()
  File "/home/blaxpirit/.local/lib/py/mkdocs/commands/serve.py", line 137, in builder
    build(config, live_server=live_server, dirty=dirty)
  File "/home/blaxpirit/.local/lib/py/mkdocs/commands/build.py", line 277, in build
    _populate_page(file.page, config, files, dirty)
  File "/home/blaxpirit/.local/lib/py/mkdocs/commands/build.py", line 175, in _populate_page
    page.render(config, files)
  File "/home/blaxpirit/.local/lib/py/mkdocs/structure/pages.py", line 175, in render
    self.content = md.convert(self.markdown)
  File "/home/blaxpirit/.local/lib/py/markdown/core.py", line 264, in convert
    root = self.parser.parseDocument(self.lines).getroot()
  File "/home/blaxpirit/.local/lib/py/markdown/blockparser.py", line 90, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
  File "/home/blaxpirit/.local/lib/py/markdown/blockparser.py", line 105, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "/home/blaxpirit/.local/lib/py/markdown/blockparser.py", line 123, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "/home/blaxpirit/.local/lib/py/mkdocstrings/extension.py", line 154, in run
    xml_element = self.process_block(identifier, block, heading_level)
  File "/home/blaxpirit/.local/lib/py/mkdocstrings/extension.py", line 193, in process_block
    data: Any = handler.collector.collect(identifier, selection)
  File "/home/blaxpirit/.local/lib/py/mkdocstrings/handlers/python.py", line 220, in collect
    raise CollectionError(error)
mkdocstrings.handlers.base.CollectionError: No module named 'mkdocstrings.pluginz'
```

</details>

<details><summary>Output for missing autodoc with this change, with MkDocs master</summary>

```
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
ERROR   -  mkdocstrings.extension: No module named 'mkdocstrings.pluginz'
Traceback (most recent call last):
  File "/home/blaxpirit/.local/lib/py/pytkdocs/cli.py", line 205, in main
    output = json.dumps(process_json(line))
  File "/home/blaxpirit/.local/lib/py/pytkdocs/cli.py", line 114, in process_json
    return process_config(json.loads(json_input))
  File "/home/blaxpirit/.local/lib/py/pytkdocs/cli.py", line 91, in process_config
    obj = loader.get_object_documentation(path, members)
  File "/home/blaxpirit/.local/lib/py/pytkdocs/loader.py", line 339, in get_object_documentation
    leaf = get_object_tree(dotted_path, self.new_path_syntax)
  File "/home/blaxpirit/.local/lib/py/pytkdocs/loader.py", line 227, in get_object_tree
    parent_module = importlib.import_module(module_path)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'mkdocstrings.pluginz'
 
ERROR   -  Error reading page 'reference/plugin.md': Could not collect 'mkdocstrings.pluginz' 

Could not collect 'mkdocstrings.pluginz'
```

Note: I'll send a pull request to MkDocs to deduplicate and change the bottom part to

```
ERROR   -  Error reading page 'reference/plugin.md':

Could not collect 'mkdocstrings.pluginz'
```

</details>

<details><summary>Output for missing autodoc with this change, with MkDocs 1.1.2</summary>

```
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
ERROR   -  mkdocstrings.extension: No module named 'mkdocstrings.pluginz'
Traceback (most recent call last):
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/pytkdocs/cli.py", line 205, in main
    output = json.dumps(process_json(line))
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/pytkdocs/cli.py", line 114, in process_json
    return process_config(json.loads(json_input))
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/pytkdocs/cli.py", line 91, in process_config
    obj = loader.get_object_documentation(path, members)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/pytkdocs/loader.py", line 339, in get_object_documentation
    leaf = get_object_tree(dotted_path, self.new_path_syntax)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/pytkdocs/loader.py", line 227, in get_object_tree
    parent_module = importlib.import_module(module_path)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'mkdocstrings.pluginz'
 
ERROR   -  mkdocstrings.extension: Error reading page 'reference/plugin/': 
Could not collect 'mkdocstrings.pluginz'
```

</details>

# Output for unparsable JSON

This is in "should never happen" territory, but it was affected too, so here's how it looks:

<details><summary>Output for bad JSON on master</summary>

```
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
ERROR   -  mkdocstrings.handlers.python: Error while loading JSON: {"loading_errors": [], "parsing_errors": {}, "objects": [{"name": "default_config", "path": "mkdocstrings.handlers.python.PythonRenderer.default_config", "category": "attribute", "file_path": "/home/blaxpirit/repos/mkdocstrings/src/mkdocstrings/handlers/python.py", "relative_file_path": "handlers/python.py", "properties": [], "parent_path": "mkdocstrings.handlers.python.PythonRenderer", "has_contents": true, "docstring": "\nThe default rendering options.\n\nOption | Type | Description | Default\n------ | ---- | ----------- | -------\n**`show_root_heading`** | `bool` | Show the heading of the object at the root of the documentation tree. | `False`\n**`show_root_toc_entry`** | `bool` | If the root heading is not shown, at least add a ToC entry for it. | `True`\n**`show_root_full_path`** | `bool` | Show the full Python path for the root object heading. | `True`\n**`show_object_full_path`** | `bool` | Show the full Python path of every object. | `False`\n**`show_root_members_full_path`** | `bool` | Show the full Python path of objects that are children of the root object (for example, classes in a module). When False, `show_object_full_path` overrides. | `False`\n**`show_category_heading`** | `bool` | When grouped by categories, show a heading for each category. | `False`\n**`show_if_no_docstring`** | `bool` | Show the object heading even if it has no docstring or children with docstrings. | `False`\n**`show_signature_annotations`** | `bool` | Show the type annotations in methods and functions signatures. | `False`\n**`show_source`** | `bool` | Show the source code of this object. | `True`\n**`group_by_category`** | `bool` | Group the object's children by categories: attributes, classes, functions, methods, and modules. | `True`\n**`heading_level`** | `int` | The initial heading level to use. | `2`\n", "docstring_sections": [{"type": "markdown", "value": "\nThe default rendering options.\n\nOption | Type | Description | Default\n------ | ---- | ----------- | -------\n**`show_root_heading`** | `bool` | Show the heading of the object at the root of the documentation tree. | `False`\n**`show_root_toc_entry`** | `bool` | If the root heading is not shown, at least add a ToC entry for it. | `True`\n**`show_root_full_path`** | `bool` | Show the full Python path for the root object heading. | `True`\n**`show_object_full_path`** | `bool` | Show the full Python path of every object. | `False`\n**`show_root_members_full_path`** | `bool` | Show the full Python path of objects that are children of the root object (for example, classes in a module). When False, `show_object_full_path` overrides. | `False`\n**`show_category_heading`** | `bool` | When grouped by categories, show a heading for each category. | `False`\n**`show_if_no_docstring`** | `bool` | Show the object heading even if it has no docstring or children with docstrings. | `False`\n**`show_signature_annotations`** | `bool` | Show the type annotations in methods and functions signatures. | `False`\n**`show_source`** | `bool` | Show the source code of this object. | `True`\n**`group_by_category`** | `bool` | Group the object's children by categories: attributes, classes, functions, methods, and modules. | `True`\n**`heading_level`** | `int` | The initial heading level to use. | `2`\n"}], "source": {}, "children": {}, "attributes": [], "methods": [], "functions": [], "modules": [], "classes": [], "type": "dict"}]}
 
ERROR   -  mkdocstrings.extension: Could not collect 'mkdocstrings.handlers.python:PythonRenderer.default_config' 
ERROR   -  Error reading page 'handlers/python.md': Expecting value: line 1 column 1 (char 0) 
Traceback (most recent call last):
  File "/home/blaxpirit/repos/mkdocstrings/src/mkdocstrings/handlers/python.py", line 212, in collect
    result = json.loads("a")
  File "/usr/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/mkdocs/__main__.py", line 192, in <module>
    cli()
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/mkdocs/__main__.py", line 133, in serve_command
    serve.serve(
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/mkdocs/commands/serve.py", line 141, in serve
    config = builder()
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/mkdocs/commands/serve.py", line 136, in builder
    build(config, live_server=live_server, dirty=dirty)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/mkdocs/commands/build.py", line 271, in build
    _populate_page(file.page, config, files, dirty)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/mkdocs/commands/build.py", line 171, in _populate_page
    page.render(config, files)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/mkdocs/structure/pages.py", line 175, in render
    self.content = md.convert(self.markdown)
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/markdown/core.py", line 264, in convert
    root = self.parser.parseDocument(self.lines).getroot()
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/markdown/blockparser.py", line 90, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/markdown/blockparser.py", line 105, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "/home/blaxpirit/.local/lib/python3.8/site-packages/markdown/blockparser.py", line 123, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "/home/blaxpirit/repos/mkdocstrings/src/mkdocstrings/extension.py", line 119, in run
    html, headings = self._process_block(identifier, block, heading_level)
  File "/home/blaxpirit/repos/mkdocstrings/src/mkdocstrings/extension.py", line 166, in _process_block
    data: CollectorItem = handler.collector.collect(identifier, selection)
  File "/home/blaxpirit/repos/mkdocstrings/src/mkdocstrings/handlers/python.py", line 215, in collect
    raise CollectionError(str(exception)) from exception
mkdocstrings.handlers.base.CollectionError: Expecting value: line 1 column 1 (char 0)
```

</details>


<details><summary>Output for bad JSON with this change, with MkDocs 1.1.2</summary>

```
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
ERROR   -  mkdocstrings.extension: Error while loading JSON
{"loading_errors": [], "parsing_errors": {}, "objects": [{"name": "default_config", "path": "mkdocstrings.handlers.python.PythonRenderer.default_config", "category": "attribute", "file_path": "/home/blaxpirit/repos/mkdocstrings/src/mkdocstrings/handlers/python.py", "relative_file_path": "handlers/python.py", "properties": [], "parent_path": "mkdocstrings.handlers.python.PythonRenderer", "has_contents": true, "docstring": "\nThe default rendering options.\n\nOption | Type | Description | Default\n------ | ---- | ----------- | -------\n**`show_root_heading`** | `bool` | Show the heading of the object at the root of the documentation tree. | `False`\n**`show_root_toc_entry`** | `bool` | If the root heading is not shown, at least add a ToC entry for it. | `True`\n**`show_root_full_path`** | `bool` | Show the full Python path for the root object heading. | `True`\n**`show_object_full_path`** | `bool` | Show the full Python path of every object. | `False`\n**`show_root_members_full_path`** | `bool` | Show the full Python path of objects that are children of the root object (for example, classes in a module). When False, `show_object_full_path` overrides. | `False`\n**`show_category_heading`** | `bool` | When grouped by categories, show a heading for each category. | `False`\n**`show_if_no_docstring`** | `bool` | Show the object heading even if it has no docstring or children with docstrings. | `False`\n**`show_signature_annotations`** | `bool` | Show the type annotations in methods and functions signatures. | `False`\n**`show_source`** | `bool` | Show the source code of this object. | `True`\n**`group_by_category`** | `bool` | Group the object's children by categories: attributes, classes, functions, methods, and modules. | `True`\n**`heading_level`** | `int` | The initial heading level to use. | `2`\n", "docstring_sections": [{"type": "markdown", "value": "\nThe default rendering options.\n\nOption | Type | Description | Default\n------ | ---- | ----------- | -------\n**`show_root_heading`** | `bool` | Show the heading of the object at the root of the documentation tree. | `False`\n**`show_root_toc_entry`** | `bool` | If the root heading is not shown, at least add a ToC entry for it. | `True`\n**`show_root_full_path`** | `bool` | Show the full Python path for the root object heading. | `True`\n**`show_object_full_path`** | `bool` | Show the full Python path of every object. | `False`\n**`show_root_members_full_path`** | `bool` | Show the full Python path of objects that are children of the root object (for example, classes in a module). When False, `show_object_full_path` overrides. | `False`\n**`show_category_heading`** | `bool` | When grouped by categories, show a heading for each category. | `False`\n**`show_if_no_docstring`** | `bool` | Show the object heading even if it has no docstring or children with docstrings. | `False`\n**`show_signature_annotations`** | `bool` | Show the type annotations in methods and functions signatures. | `False`\n**`show_source`** | `bool` | Show the source code of this object. | `True`\n**`group_by_category`** | `bool` | Group the object's children by categories: attributes, classes, functions, methods, and modules. | `True`\n**`heading_level`** | `int` | The initial heading level to use. | `2`\n"}], "source": {}, "children": {}, "attributes": [], "methods": [], "functions": [], "modules": [], "classes": [], "type": "dict"}]}

Traceback (most recent call last):
  File "/home/blaxpirit/repos/mkdocstrings/src/mkdocstrings/handlers/python.py", line 213, in collect
    result = json.loads("a")
  File "/usr/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
 
ERROR   -  mkdocstrings.extension: Error reading page 'handlers/python/': 
Could not collect 'mkdocstrings.handlers.python:PythonRenderer.default_config'
```

</details>
