### PR TITLE
docs: Details about autorefs, reorganize nav, update links & more

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -10,4 +10,4 @@ assignees: ''
 **Add detailed information, like**
 - project folder structure (`tree -L 2`)
 - `mkdocs.yml` configuration file contents
-- `mkdocstrings` version: [e.g. 0.10.2]
+- *mkdocstrings* version: [e.g. 0.10.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <small>[Compare with 0.13.6](https://github.com/pawamoy/mkdocstrings/compare/0.13.6...0.14.0)</small>
 
 Special thanks to Oleh [@oprypin](https://github.com/oprypin) Prypin who did an amazing job (this is a euphemism)
-at improving MkDocstrings, fixing hard-to-fix bugs with clever solutions, implementing great new features
+at improving *mkdocstrings*, fixing hard-to-fix bugs with clever solutions, implementing great new features
 and refactoring the code for better performance and readability! Thanks Oleh!
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # mkdocstrings
 
-[![ci](https://github.com/pawamoy/mkdocstrings/workflows/ci/badge.svg)](https://github.com/pawamoy/mkdocstrings/actions?query=workflow%3Aci)
-[![documentation](https://img.shields.io/badge/docs-mkdocs%20material-blue.svg?style=flat)](https://pawamoy.github.io/mkdocstrings/)
+[![ci](https://github.com/mkdocstrings/mkdocstrings/workflows/ci/badge.svg)](https://github.com/mkdocstrings/mkdocstrings/actions?query=workflow%3Aci)
+[![documentation](https://img.shields.io/badge/docs-mkdocs%20material-blue.svg?style=flat)](https://mkdocstrings.github.io/)
 [![pypi version](https://img.shields.io/pypi/v/mkdocstrings.svg)](https://pypi.org/project/mkdocstrings/)
 [![conda version](https://img.shields.io/conda/vn/conda-forge/mkdocstrings)](https://anaconda.org/conda-forge/mkdocstrings)
 [![gitter](https://badges.gitter.im/join%20chat.svg)](https://gitter.im/mkdocstrings/community)
 
-Automatic documentation from sources, for MkDocs.
+Automatic documentation from sources, for [MkDocs](https://mkdocs.org/).
 
 ---
 
@@ -22,33 +22,50 @@ Automatic documentation from sources, for MkDocs.
 
 ## Features
 
-- **Language agnostic:** just like `mkdocs`, `mkdocstrings` is written in Python but is language-agnostic.
-  It means you can use it for any language, as long as you implement a
-  [`handler`](https://pawamoy.github.io/mkdocstrings/reference/handlers/__init__/) for it.
-  Currently, we only have a [Python handler](https://pawamoy.github.io/mkdocstrings/reference/handlers/python/).
-  Maybe you'd like to contribute another one :wink:?
-- **Multiple themes support:** each handler can offer multiple themes. Currently, we offer the
+- [**Language-agnostic:**](https://mkdocstrings.github.io/handlers/overview/)
+  just like *MkDocs*, *mkdocstrings* is written in Python but is language-agnostic.
+  It means you can use it with any programming language, as long as there is a
+  [**handler**](https://mkdocstrings.github.io/reference/handlers/base/) for it.
+  The [Python handler](https://mkdocstrings.github.io/handlers/python/) is built-in.
+  [Others](https://mkdocstrings.github.io/handlers/overview/) are external.
+  Maybe you'd like to add another one to the list? :wink:
+
+- [**Multiple themes support:**](https://mkdocstrings.github.io/theming/)
+  each handler can offer multiple themes. Currently, we offer the
   :star: [Material theme](https://squidfunk.github.io/mkdocs-material/) :star:
   as well as basic support for the ReadTheDocs theme for the Python handler.
-- **Cross-references to other objects:** `mkdocstrings` makes it possible to reference other headings from your
-  Markdown files with the classic Markdown syntax: `[identifier][]` or `[title][identifier]`. This feature is language
-  agnostic as well: you can cross-reference any heading that appear in your Markdown pages.
-  If the handler for a particular language renders headings for documented objects, you'll be able to reference them!
-- **Inline injection in Markdown:** instead of generating Markdown files, `mkdocstrings` allows you to inject
+
+- [**Cross-links across pages:**](https://mkdocstrings.github.io/usage/#cross-references)
+  *mkdocstrings* makes it possible to reference headings in other Markdown files with the classic Markdown linking
+  syntax: `[identifier][]` or `[title][identifier]` -- and you don't need to remember which exact page this object was
+  on. This works for any heading that's produced by a *mkdocstrings* language handler, and you can opt to include
+  *any* Markdown heading into the global referencing scheme.
+
+    **Note**: in versions prior to 0.15 *all* Markdown headers were included, but now you need to
+    [opt in](https://mkdocstrings.github.io/usage/#cross-references).
+
+- [**Inline injection in Markdown:**](https://mkdocstrings.github.io/usage/)
+  instead of generating Markdown files, *mkdocstrings* allows you to inject
   documentation anywhere in your Markdown contents. The syntax is simple: `::: identifier` followed by a 4-spaces
   indented YAML block. The identifier and YAML configuration will be passed to the appropriate handler
   to collect and render documentation.
-- **Global and local configuration:** each handler can be configured globally in `mkdocs.yml`, and locally for each
+
+- [**Global and local configuration:**](https://mkdocstrings.github.io/usage/#global-options)
+  each handler can be configured globally in `mkdocs.yml`, and locally for each
   "autodoc" instruction.
-- **Watch source code directories:** you can tell `mkdocstrings` to add directories to be watched by `mkdocs` when
+
+- [**Watch source code directories:**](https://mkdocstrings.github.io/usage/#watch-directories)
+  you can tell *mkdocstrings* to add directories to be watched by *MkDocs* when
   serving the documentation, for auto-reload.
-- **Sane defaults:** you should be able to just drop the plugin in your configuration and enjoy your auto-generated docs.
+
+- **Reasonable defaults:**
+  you should be able to just drop the plugin in your configuration and enjoy your auto-generated docs.
 
 ### Python handler features
 
 - **Data collection from source code**: collection of the object-tree and the docstrings is done by
   [`pytkdocs`](https://github.com/pawamoy/pytkdocs). The following features are possible thanks to it:
-    - **Support for type annotations:** `pytkdocs` collects your type annotations and `mkdocstrings` uses them
+    - **Support for type annotations:** `pytkdocs` collects your type annotations and *mkdocstrings* uses them
       to display parameters types or return types.
     - **Recursive documentation of Python objects:** just use the module dotted-path as identifier, and you get the full
       module docs. You don't need to inject documentation for each class, function, etc.
@@ -56,37 +73,37 @@ Automatic documentation from sources, for MkDocs.
       be recognized by `pytkdocs` in modules, classes and even in `__init__` methods.
     - **Support for objects properties:** `pytkdocs` detects if a method is a `staticmethod`, a `classmethod`, etc.,
       it also detects if a property is read-only or writable, and more! These properties will be displayed
-      next to the object signature by `mkdocstrings`.
+      next to the object signature by *mkdocstrings*.
     - **Google-style sections support in docstrings:** `pytkdocs` understands `Arguments:`, `Raises:`
-      and `Returns:` sections, and returns structured data for `mkdocstrings` to render them.
+      and `Returns:` sections, and returns structured data for *mkdocstrings* to render them.
     - **reStructuredText-style sections support in docstrings:** `pytkdocs` understands all the
       [reStructuredText fields](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html?highlight=python%20domain#info-field-lists),
-      and returns structured data for `mkdocstrings` to render them.
+      and returns structured data for *mkdocstrings* to render them.
       *Note: only RST **style** is supported, not the whole markup.*
     - **Admonition support in docstrings:** blocks like `Note: ` or `Warning: ` will be transformed
       to their [admonition](https://squidfunk.github.io/mkdocs-material/extensions/admonition/) equivalent.
       *We do not support nested admonitions in docstrings!*
     - **Support for reStructuredText in docstrings:** `pytkdocs` can parse simple RST.
-- **Every object has a TOC entry:** we render a heading for each object, meaning `mkdocs` picks them into the Table
-  of Contents, which is nicely display by the Material theme. Thanks to `mkdocstrings` cross-reference ability,
+- **Every object has a TOC entry:** we render a heading for each object, meaning *MkDocs* picks them into the Table
+  of Contents, which is nicely display by the Material theme. Thanks to *mkdocstrings* cross-reference ability,
   you can even reference other objects within your docstrings, with the classic Markdown syntax:
   `[this object][package.module.object]` or directly with `[package.module.object][]`
-- **Source code display:** `mkdocstrings` can add a collapsible div containing the highlighted source code
+- **Source code display:** *mkdocstrings* can add a collapsible div containing the highlighted source code
   of the Python object.
 
-To get an example of what is possible, check `mkdocstrings`'
-own [documentation](https://pawamoy.github.io/mkdocstrings), auto-generated from sources by itself of course,
+To get an example of what is possible, check *mkdocstrings*'
+own [documentation](https://mkdocstrings.github.io/), auto-generated from sources by itself of course,
 and the following GIF:
 
 ![mkdocstrings_gif2](https://user-images.githubusercontent.com/3999221/77157838-7184db80-6aa2-11ea-9f9a-fe77405202de.gif)
 
 ## Roadmap
 
-See the [Feature Roadmap issue](https://github.com/pawamoy/mkdocstrings/issues/183) on the bugtracker.
+See the [Feature Roadmap issue](https://github.com/mkdocstrings/mkdocstrings/issues/183) on the bugtracker.
 
 ## Requirements
 
-`mkdocstrings` requires Python 3.6 or above.
+*mkdocstrings* requires Python 3.6 or above.
 
 <details>
 <summary>To install Python 3.6, I recommend using <a href="https://github.com/pyenv/pyenv"><code>pyenv</code></a>.</summary>
@@ -141,10 +158,10 @@ plugins:
 
 In one of your markdown files:
 
-```yaml
+```markdown
 # Reference
 
 ::: my_library.my_module.my_class
 ```
 
-See the [Usage](https://pawamoy.github.io/mkdocstrings/usage) section of the docs for more examples!
+See the [Usage](https://mkdocstrings.github.io/usage) section of the docs for more examples!

--- a/docs/css/mkdocstrings.css
+++ b/docs/css/mkdocstrings.css
@@ -1,6 +1,0 @@
-/* Indentation. */
-div.doc-contents:not(.first) {
-  padding-left: 25px;
-  border-left: 4px solid rgba(230, 230, 230);
-  margin-bottom: 80px;
-}

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,0 +1,17 @@
+/* Indentation for mkdocstrings items. */
+div.doc-contents:not(.first) {
+  padding-left: 25px;
+  border-left: 4px solid rgba(230, 230, 230);
+  margin-bottom: 80px;
+}
+
+/* Mark external links as such (also in nav) */
+a.external:hover::after, a.md-nav__link[href^="https:"]:hover::after {
+  /* https://primer.style/octicons/link-external-16 */
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="rgb(233, 235, 252)" d="M10.604 1h4.146a.25.25 0 01.25.25v4.146a.25.25 0 01-.427.177L13.03 4.03 9.28 7.78a.75.75 0 01-1.06-1.06l3.75-3.75-1.543-1.543A.25.25 0 0110.604 1zM3.75 2A1.75 1.75 0 002 3.75v8.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 12.25v-3.5a.75.75 0 00-1.5 0v3.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-8.5a.25.25 0 01.25-.25h3.5a.75.75 0 000-1.5h-3.5z"></path></svg>');
+  height: 0.8em;
+  width: 0.8em;
+  margin-left: 0.2em;
+  content: ' ';
+  display: inline-block;
+}

--- a/docs/handlers/overview.md
+++ b/docs/handlers/overview.md
@@ -4,7 +4,8 @@ A handler is what makes it possible to collect and render documentation for a pa
 
 ## Available handlers
 
-- [Python](../python)
+- [Python](python.md)
+- <a class="external" href="https://mkdocstrings.github.io/crystal/">Crystal</a>
 
 ## Custom handlers
 
@@ -14,23 +15,13 @@ thanks to namespace packages. For more information about namespace packages,
 
 ### Packaging
 
-For MkDocstrings, a custom handler package would have the following structure:
+For *mkdocstrings*, a custom handler package would have the following structure:
 
 ```
 📁 your_repository
-└── 📁 mkdocstrings
-    └── 📁 handlers
-        └── 📄 custom_handler.py
-```
-
-Or with a `src` layout:
-
-```
-📁 your_repository
-└── 📁 src
-    └── 📁 mkdocstrings
-        └── 📁 handlers
-            └── 📄 custom_handler.py
+└─╴📁 mkdocstrings
+   └─╴📁 handlers
+      └─╴📄 custom_handler.py
 ```
 
 **Note the absence of `__init__.py` modules!**
@@ -89,22 +80,21 @@ your renderer.
 
 ### Usage
 
-When a custom handler is installed,
-it is then available to MkDocstrings.
+When a custom handler is installed, it is then available to *mkdocstrings*.
 You can configure it as usual:
 
-```yaml
-# mkdocs.yml
-plugins:
-- mkdocstrings:
-    handlers:
-      custom_handler:
-        selection:
-          some_config_option: "a"
-        rendering:
-          other_config_option: 0
-        handler_config_option: yes
-```
+!!! example "mkdocs.yml"
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          custom_handler:
+            selection:
+              some_config_option: "a"
+            rendering:
+              other_config_option: 0
+            handler_config_option: yes
+    ```
 
 ...and use it in your autodoc instructions:
 

--- a/docs/handlers/python.md
+++ b/docs/handlers/python.md
@@ -116,7 +116,7 @@ in [Napoleon's documentation](https://sphinxcontrib-napoleon.readthedocs.io/en/l
 
 ##### Sections
 
-Docstrings sections are parsed by `pytkdocs` and rendered by MkDocstrings.
+Docstrings sections are parsed by `pytkdocs` and rendered by *mkdocstrings*.
 Supported sections are:
 
 - `Arguments` (or `Args`, `Parameters`, `Params`)
@@ -217,7 +217,7 @@ in [Sphinx's documentation](https://sphinx-rtd-tutorial.readthedocs.io/en/latest
 
 ##### Sections
 
-Docstrings directives are parsed by `pytkdocs` and rendered by MkDocstrings.
+Docstrings directives are parsed by `pytkdocs` and rendered by *mkdocstrings*.
 Supported directives are:
 
 - `param` (or `parameter`, `arg`, `argument`, `key`, `keyword`)
@@ -301,21 +301,21 @@ You may want to to generate documentation for a package while its dependencies a
 The Python handler provides itself no builtin way to mock libraries,
 but you can use the `setup_commands` to mock them manually:
 
-```yaml
-# mkdocs.yml
-plugins:
-  - mkdocstrings:
-      handlers:
-        python:
-          setup_commands:
-            - import sys
-            - from unittest.mock import MagicMock as mock
-            - sys.modules["lib1"] = mock()
-            - sys.modules["lib2"] = mock()
-            - sys.modules["lib2.module1"] = mock()
-            - sys.modules["lib2.module1.moduleB"] = mock()
-            # etc
-```
+!!! example "mkdocs.yml"
+    ```yaml
+    plugins:
+      - mkdocstrings:
+          handlers:
+            python:
+              setup_commands:
+                - import sys
+                - from unittest.mock import MagicMock as mock
+                - sys.modules["lib1"] = mock()
+                - sys.modules["lib2"] = mock()
+                - sys.modules["lib2.module1"] = mock()
+                - sys.modules["lib2.module1.moduleB"] = mock()
+                # etc
+    ```
 
 ## Recommended style (Material)
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,130 @@
+# Themes
+
+*mkdocstrings* can support multiple MkDocs themes.
+It currently supports supports the
+*[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)*
+theme and, partially, the built-in ReadTheDocs theme.
+
+Each renderer can fallback to a particular theme when the user selected theme is not supported.
+For example, the Python renderer will fallback to the *Material for MkDocs* templates.
+
+## Customization
+
+There is some degree of customization possible in *mkdocstrings*.
+First, you can write custom templates to override the theme templates.
+Second, the provided templates make use of CSS classes,
+so you can tweak the look and feel with extra CSS rules.
+
+### Templates
+
+To use custom templates and override the theme ones,
+specify the relative path to your templates directory
+with the `custom_templates` global configuration option:
+
+!!! example "mkdocs.yml"
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        custom_templates: templates
+    ```
+
+You directory structure must be identical to the provided templates one:
+
+```
+templates
+├─╴<HANDLER 1>
+│   ├── <THEME 1>
+│   └── <THEME 2>
+└── <HANDLER 2>
+    ├── <THEME 1>
+    └── <THEME 2>
+```
+
+(*[Check out the template tree on GitHub](https://github.com/mkdocstrings/mkdocstrings/tree/master/src/mkdocstrings/templates/)*)
+
+You don't have to replicate the whole tree,
+only the handlers, themes or templates you want to override.
+For example, to override some templates of the *Material* theme for Python:
+
+```
+templates
+└── python
+    └── material
+        ├── parameters.html
+        └── exceptions.html
+```
+
+In the HTML files, replace the original contents with your modified version.
+In the future, the templates will use Jinja blocks, so it will be easier
+to modify a small part of the template without copy-pasting the whole file.
+
+The *Material* theme provides the following template structure:
+
+- `children.html`: where the recursion happen, to render all children of an object
+    - `attribute.html`: to render attributes (class-attributes, etc.)
+    - `class.html`: to render classes
+    - `function.html`: to render functions
+    - `method.html`: to render methods
+    - `module.html`: to render modules
+- `docstring.html`: to render docstrings
+    - `attributes.html`: to render attributes sections of docstrings
+    - `examples.html`: to render examples sections of docstrings
+    - `exceptions.html`: to render exceptions/"raises" sections of docstrings
+    - `parameters.html`: to render parameters/arguments sections of docstrings
+    - `return.html`: to render "return" sections of docstrings
+- `properties.html`: to render the properties of an object (`staticmethod`, `read-only`, etc.)
+- `signature.html`: to render functions and methods signatures
+
+#### Debugging
+
+Every template has access to a `log` function, allowing to log messages as usual:
+
+```jinja
+{{ log.debug("A DEBUG message.") }}
+{{ log.info("An INFO message.") }}
+{{ log.warning("A WARNING message.") }}
+{{ log.error("An ERROR message.") }}
+{{ log.critical("A CRITICAL message.") }}
+```
+
+### CSS classes
+
+The *Material* theme uses the following CSS classes in the HTML:
+
+- `doc`: on all the following elements
+- `doc-children`: on `div`s containing the children of an object
+- `doc-object`: on `div`s containing an object
+    - `doc-attribute`: on `div`s containing an attribute
+    - `doc-class`: on `div`s containing a class
+    - `doc-function`: on `div`s containing a function
+    - `doc-method`: on `div`s containing a method
+    - `doc-module`: on `div`s containing a module
+- `doc-heading`: on objects headings
+- `doc-contents`: on `div`s wrapping the docstring then the children (if any)
+    - `first`: same, but only on the root object's contents `div`
+- `doc-properties`: on `span`s wrapping the object's properties
+    - `doc-property`: on `small` elements containing a property
+        - `doc-property-PROPERTY`: same, where `PROPERTY` is replaced by the actual property
+
+!!! example "Example with colorful properties"
+    === "CSS"
+        ```css
+        .doc-property { border-radius: 15px; padding: 0 5px; }
+        .doc-property-special { background-color: blue; color: white; }
+        .doc-property-private { background-color: red; color: white; }
+        .doc-property-property { background-color: green; color: white; }
+        .doc-property-read-only { background-color: yellow; color: black; }
+        ```
+
+    === "Result"
+        <style>
+          .prop { border-radius: 15px; padding: 0 5px; }
+        </style>
+        <h3 style="margin: 0;"><span>
+            <small class="prop" style="background-color: blue; color: white !important;">special</small>
+            <small class="prop" style="background-color: red; color: white !important;">private</small>
+            <small class="prop" style="background-color: green; color: white !important;">property</small>
+            <small class="prop" style="background-color: yellow; color: black !important;">read-only</small>
+        </span></h3>
+
+        As you can see, CSS is not my field of predilection...

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@ Please upgrade to version 0.14 or higher.
 
 See also:
 
-- [Issue #186](https://github.com/pawamoy/mkdocstrings/issues/186)
+- [Issue #186](https://github.com/mkdocstrings/mkdocstrings/issues/186)
 - [Tabs in docstrings (from `pymdownx.tabbed`) are not working properly](#tabs-in-docstrings-from-pymdownxtabbed-are-not-working-properly).
 
 ## MkDocs warns me about links to unfound documentation files
@@ -46,80 +46,72 @@ It shows that it's probably a cross-reference, not a direct link.
 It's probably written like `[Section](pytkdocs.parsers.docstrings.Section)` in the docs,
 when it should be `[Section][pytkdocs.parsers.docstrings.Section]`.
 
-## Nothing is rendered at all
-
-Python?
-
-- "No": we only support Python right now.
-- "Yes": is your package available in the Python path?
-  See [Python handler: Finding module](../handlers/python/#finding-modules).
-
 ## Some objects are not rendered (they do not appear in the generated docs)
 
 - Make sure the configuration options of the handler for both selection and rendering are correct.
-  Check the documentation for [Handlers](../handlers/overview) to see the available options for each handler.
+  Check the documentation for [Handlers](handlers/overview.md) to see the available options for each handler.
 - Also make sure your documentation in your source code is formatted correctly.
-  For Python code, check the [supported docstring styles](../handlers/python/#supported-docstrings-styles) page.
+  For Python code, check the [supported docstring styles](handlers/python.md#supported-docstrings-styles) page.
 - Re-run the Mkdocs command with `-v`, and carefully read any traceback.
 
 ## Tabs in docstrings (from `pymdownx.tabbed`) are not working properly
 
-Before version 0.14, multiple tabs blocks injected on the same page
+Before version 0.14, multiple tab blocks injected on the same page
 would result in broken links: clicking on a tab would bring the user to the wrong one.
 Please upgrade to version 0.14 or higher.
 
 See also:
 
-- [Issue #193](https://github.com/pawamoy/mkdocstrings/issues/193)
+- [Issue #193](https://github.com/mkdocstrings/mkdocstrings/issues/193)
 - [Footnotes are duplicated or overridden](#footnotes-are-duplicated-or-overridden).
 
-**JavaScript workaround:**
-
-If you are stuck on version lower than 0.14,
-and want to use multiple tabs blocks in one page,
+If you are stuck on a version before 0.14,
+and want to use multiple tab blocks in one page,
 use this workaround.
 
-Put the following code in a .js file,
-and list it in MkDocs' `extra_javascript`: 
+??? example "JavaScript workaround"
 
-```javascript
-// Credits to Nikolaos Zioulis (@zuru on GitHub)
-function setID(){
-    var tabs = document.getElementsByClassName("tabbed-set");
-    for (var i = 0; i < tabs.length; i++) {
-        children = tabs[i].children;
-        var counter = 0;
-        var iscontent = 0;
-        for(var j = 0; j < children.length;j++){
-            if(typeof children[j].htmlFor === 'undefined'){
-                if((iscontent + 1) % 2 == 0){
-                    // check if it is content
-                    if(iscontent == 1){
-                        btn = children[j].childNodes[1].getElementsByTagName("button");
+    Put the following code in a .js file,
+    and list it in MkDocs' `extra_javascript`:
+
+    ```javascript
+    // Credits to Nikolaos Zioulis (@zuru on GitHub)
+    function setID(){
+        var tabs = document.getElementsByClassName("tabbed-set");
+        for (var i = 0; i < tabs.length; i++) {
+            children = tabs[i].children;
+            var counter = 0;
+            var iscontent = 0;
+            for(var j = 0; j < children.length;j++){
+                if(typeof children[j].htmlFor === 'undefined'){
+                    if((iscontent + 1) % 2 == 0){
+                        // check if it is content
+                        if(iscontent == 1){
+                            btn = children[j].childNodes[1].getElementsByTagName("button");
+                        }
                     }
+                    else{
+                        // if not change the id
+                        children[j].id = "__tabbed_" + String(i + 1) + "_" + String(counter + 1);
+                        children[j].name = "__tabbed_" + String(i + 1);
+                        // make default tab open
+                        if(j == 0)
+                            children[j].click();
+                    }
+                    iscontent++;
                 }
                 else{
-                    // if not change the id
-                    children[j].id = "__tabbed_" + String(i + 1) + "_" + String(counter + 1);
-                    children[j].name = "__tabbed_" + String(i + 1);
-                    // make default tab open
-                    if(j == 0)
-                        children[j].click();
+                    // link to the correct tab
+                    children[j].htmlFor = "__tabbed_" + String(i+1) + "_" + String(counter + 1);
+                    counter ++;
                 }
-                iscontent++;
-            }
-            else{
-                // link to the correct tab
-                children[j].htmlFor = "__tabbed_" + String(i+1) + "_" + String(counter + 1);
-                counter ++;
             }
         }
     }
-}
-setID();
-```
+    setID();
+    ```
 
-This code will correctly reset the IDs for tabs on a same page.
+    This code will correctly reset the IDs for tabs on a same page.
 
 ## The generated documentation does not look good
 
@@ -130,12 +122,16 @@ Are you using the Material theme?
   asking to support your theme. If you find one, vote with a thumbs up. If not, you can open a ticket.
 - "Yes": Please open an ticket on the [bugtracker][bugtracker] with a detailed
   explanation and screenshots of the bad-looking parts.
-  
+
+Note that you can always [customize the look](theming.md) of *mkdocstrings* blocks -- through both HTML and CSS.
+
 ## Warning: could not find cross-reference target
 
-- Make sure you have defined `site_url` in `mkdocs.yml`, as it is required for cross-references when building the site
-  (the error does not happen when serving because then `site_url` is auto-populated by `mkdocs`).
-- Make sure the referenced object was both collected and rendered: verify your selection and rendering options.
+!!! important "New in version 0.15"
+    Cross-linking used to include any Markdown heading, but now it's only for *mkdocstrings* identifiers by default.
+    See [Cross-references to any Markdown heading](usage.md#cross-references-to-any-markdown-heading) to opt back in.
+
+Make sure the referenced object was both collected and rendered: verify your selection and rendering options.
 
 For false-positives, you can wrap the text in backticks (\`) to prevent `mkdocstrings` from trying to process it.
 
@@ -165,6 +161,12 @@ Version 2.11.1 seems to be working fine.
 ---
 
 ## Python specifics
+
+### Nothing is rendered at all
+
+Is your package available in the Python path?
+
+See [Python handler: Finding modules](handlers/python.md#finding-modules).
 
 ### LaTeX in docstrings is not rendered correctly
 
@@ -260,7 +262,7 @@ def my_function(*args, **kwargs):
     print(*args, **kwargs)
 ```
 
-[bugtracker]: https://github.com/pawamoy/mkdocstrings
+[bugtracker]: https://github.com/mkdocstrings/mkdocstrings
 [pytkdocs]: https://github.com/pawamoy/pytkdocs
 [inspect]: https://docs.python.org/3/library/inspect.html
 [ast]: https://docs.python.org/3/library/ast.html

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,14 +2,14 @@
 
 ## Autodoc syntax
 
-MkDocstrings works by processing special expressions in your Markdown files.
+*mkdocstrings* works by processing special expressions in your Markdown files.
 
 The syntax is as follows:
 
 ```md
 ::: identifier
     YAML block
-``` 
+```
 
 The `identifier` is a string identifying the object you want to document.
 The format of an identifier can vary from one handler to another.
@@ -30,13 +30,13 @@ The YAML block is optional, and contains some configuration options:
 
 Every handler accepts at least these two keys, `selection` and `rendering`,
 and some handlers accept additional keys.
-Check the documentation for your handler of interest in [Handlers](../handlers/overview).
+Check the documentation for your handler of interest in [Handlers](handlers/overview.md).
 
 !!! example "Example with the Python handler"
     === "docs/my_page.md"
         ```md
         # Documentation for `MyClass`
-        
+
         ::: my_package.my_module.MyClass
             handler: python
             selection:
@@ -47,31 +47,31 @@ Check the documentation for your handler of interest in [Handlers](../handlers/o
               show_root_heading: false
               show_source: false
         ```
-        
+
     === "mkdocs.yml"
         ```yaml
         nav:
           - "My page": my_page.md
         ```
-          
+
     === "src/my_package/my_module.py"
         ```python
         class MyClass:
             """Print print print!"""
-            
+
             def method_a(self):
                 """Print A!"""
                 print("A!")
-               
+
             def method_b(self):
                 """Print B!"""
                 print("B!")
-                
+
             def method_c(self):
                 """Print C!"""
                 print("C!")
         ```
-        
+
     === "Result"
         <h3 id="documentation-for-myclass" style="margin: 0;">Documentation for <code>MyClass</code></h3>
         <div><div><p>Print print print!</p><div><div>
@@ -101,34 +101,33 @@ The above is equivalent to:
       heading_level: 2
 ```
 
-
-
 ## Global options
 
-MkDocstrings accept a few top-level configuration options in `mkdocs.yml`:
+*mkdocstrings* accepts a few top-level configuration options in `mkdocs.yml`:
 
 - `watch`: a list of directories to watch while serving the documentation.
   See [Watch directories](#watch-directories).
 - `default_handler`: the handler that is used by default when no handler is specified.
 - `custom_templates`: the path to a directory containing custom templates.
   The path is relative to the docs directory.
-  See [Customization](#customization).
+  See [Theming](theming.md).
 - `handlers`: the handlers global configuration.
 
 Example:
 
-```yaml
-plugins:
-- mkdocstrings:
-    default_handler: python
-    handlers:
-      python:
-        rendering:
-          show_source: false  
-    custom_templates: templates
-    watch:
-      - src/my_package
-```
+!!! example "mkdocs.yml"
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        default_handler: python
+        handlers:
+          python:
+            rendering:
+              show_source: false
+        custom_templates: templates
+        watch:
+          - src/my_package
+    ```
 
 The handlers global configuration can then be overridden by local configurations:
 
@@ -146,11 +145,11 @@ Cross-references are written as Markdown *reference-style* links:
     ```md
     With a custom title:
     [`Object 1`][full.path.object1]
-    
+
     With the identifier as title:
     [full.path.object2][]
     ```
-    
+
 === "HTML Result"
     ```html
     <p>With a custom title:
@@ -169,149 +168,62 @@ Web browser will show in the URL bar when clicking an item's entry in the table 
 If the URL is `https://example.com/some/page.html#full.path.object1` then you know that this item
 is possible to link to with `[example][full.path.object1]`, regardless of the current page.
 
-## Themes
+### Cross-references to any Markdown heading
 
-MkDocstrings can support multiple MkDocs themes.
-It currently supports supports the
-*[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)*
-theme and, partially, the built-in ReadTheDocs theme.
+If you want to link to *any* Markdown heading, not just *mkdocstrings*-inserted items, please
+enable the [*autorefs* plugin for *MkDocs*](https://github.com/mkdocstrings/autorefs) by adding
+`autorefs` to `plugins`:
 
-Each renderer can fallback to a particular theme when the user selected theme is not supported.
-For example, the Python renderer will fallback to the *Material for MkDocs* templates.
+!!! example "mkdocs.yml"
+    ```yaml hl_lines="4"
+    plugins:
+      - admonition
+      - search
+      - autorefs
+      - mkdocstrings:
+          [...]
+    ```
 
-## Customization
+Prior to *mkdocstrings* version 0.15 this was the default, but now opt-in is required.
 
-There is some degree of customization possible in MkDocstrings.
-First, you can write custom templates to override the theme templates.
-Second, the provided templates make use of CSS classes,
-so you can tweak the look and feel with extra CSS rules. 
+Note that you don't need to (`pip`) install anything more; this plugin is guaranteed to be pulled in with *mkdocstrings*.
 
-### Templates
 
-To use custom templates and override the theme ones,
-specify the relative path to your templates directory
-with the `custom_templates` global configuration option:
+!!! example
+    === "doc1.md"
+        ```md
+        ## Hello, world!
 
-```yaml
-# mkdocs.yml
-plugins:
-  - mkdocstrings:
-      custom_templates: templates
-```
-
-You directory structure must be identical to the provided templates one:
-
-```
-templates
-├── <HANDLER 1>
-│   ├── <THEME 1>
-│   └── <THEME 2>
-└── <HANDLER 2>
-    ├── <THEME 1>
-    └── <THEME 2>
-```
-
-(*[Check out the template tree on GitHub](https://github.com/pawamoy/mkdocstrings/tree/master/src/mkdocstrings/templates/)*)
-
-You don't have to replicate the whole tree,
-only the handlers, themes or templates you want to override.
-For example, to override some templates of the *Material* theme for Python:
-
-```
-templates
-└── python
-    └── material
-        ├── parameters.html
-        └── exceptions.html
-```
-
-In the HTML files, replace the original contents with your modified version.
-In the future, the templates will use Jinja blocks, so it will be easier
-to modify a small part of the template without copy-pasting the whole file.
-
-The *Material* theme provides the following template structure:
-
-- `children.html`: where the recursion happen, to render all children of an object
-    - `attribute.html`: to render attributes (class-attributes, etc.)
-    - `class.html`: to render classes
-    - `function.html`: to render functions
-    - `method.html`: to render methods
-    - `module.html`: to render modules
-- `docstring.html`: to render docstrings
-    - `attributes.html`: to render attributes sections of docstrings
-    - `examples.html`: to render examples sections of docstrings
-    - `exceptions.html`: to render exceptions/"raises" sections of docstrings
-    - `parameters.html`: to render parameters/arguments sections of docstrings
-    - `return.html`: to render "return" sections of docstrings
-- `properties.html`: to render the properties of an object (`staticmethod`, `read-only`, etc.)
-- `signature.html`: to render functions and methods signatures
-
-#### Debugging
-
-Every template has access to a `log` function, allowing to log messages as usual:
-
-```jinja
-{{ log.debug("A DEBUG message.") }}
-{{ log.info("An INFO message.") }}
-{{ log.warning("A WARNING message.") }}
-{{ log.error("An ERROR message.") }}
-{{ log.critical("A CRITICAL message.") }}
-```
-
-### CSS classes
-
-The *Material* theme uses the following CSS classes in the HTML:
-
-- `doc`: on all the following elements
-- `doc-children`: on `div`s containing the children of an object
-- `doc-object`: on `div`s containing an object
-    - `doc-attribute`: on `div`s containing an attribute 
-    - `doc-class`: on `div`s containing a class 
-    - `doc-function`: on `div`s containing a function 
-    - `doc-method`: on `div`s containing a method 
-    - `doc-module`: on `div`s containing a module 
-- `doc-heading`: on objects headings 
-- `doc-contents`: on `div`s wrapping the docstring then the children (if any)
-    - `first`: same, but only on the root object's contents `div`
-- `doc-properties`: on `span`s wrapping the object's properties
-    - `doc-property`: on `small` elements containing a property
-        - `doc-property-PROPERTY`: same, where `PROPERTY` is replaced by the actual property
-        
-!!! example "Example with colorful properties"
-    === "CSS"
-        ```css
-        .doc-property { border-radius: 15px; padding: 0 5px; }
-        .doc-property-special { background-color: blue; color: white; }
-        .doc-property-private { background-color: red; color: white; }
-        .doc-property-property { background-color: green; color: white; }
-        .doc-property-read-only { background-color: yellow; color: black; }
+        Testing
         ```
-        
-    === "Result"
-        <style>
-          .prop { border-radius: 15px; padding: 0 5px; }
-        </style>
-        <h3 style="margin: 0;"><span>
-            <small class="prop" style="background-color: blue; color: white !important;">special</small>
-            <small class="prop" style="background-color: red; color: white !important;">private</small>
-            <small class="prop" style="background-color: green; color: white !important;">property</small>
-            <small class="prop" style="background-color: yellow; color: black !important;">read-only</small>
-        </span></h3>
-        
-        As you can see, CSS is not my field of predilection...
+
+    === "doc2.md"
+        ```md
+        ## Something else
+
+        Please see the [Hello, World!][hello-world] section.
+        ```
+
+    === "Result HTML for doc2"
+        ```html
+        <p>Please see the <a href="doc1.html#hello-world">Hello, World!</a> section.</p>
+        ```
+
 
 ## Watch directories
 
 You can add directories to watch with the `watch` key.
 It accepts a list of paths.
 
-```yaml
-plugins:
-  - mkdocstrings:
-      watch:
-        - src/my_package_1
-        - src/my_package_2
-```
+!!! example "mkdocs.yml"
+    ```yaml
+    plugins:
+      - mkdocstrings:
+          watch:
+            - src/my_package_1
+            - src/my_package_2
+    ```
+
 When serving your documentation
 and a change occur in one of the listed path,
 MkDocs will rebuild the site and reload the current page.
@@ -321,4 +233,4 @@ MkDocs will rebuild the site and reload the current page.
     For example, it will not tell the Python handler to look for packages in these paths
     (the paths are not added to the `PYTHONPATH` variable).
     If you want to tell Python where to look for packages and modules,
-    see [Python Handler: Finding modules](../handlers/python/#finding-modules).
+    see [Python Handler: Finding modules](handlers/python.md#finding-modules).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,19 +2,18 @@ site_name: "mkdocstrings"
 site_description: "Automatic documentation from sources, for MkDocs."
 site_url: "https://mkdocstrings.github.io/"
 repo_url: "https://github.com/mkdocstrings/mkdocstrings"
+edit_uri: "blob/master/docs/"
 repo_name: "mkdocstrings/mkdocstrings"
 
 nav:
-- Home:
-  - Overview: index.md
-  - Changelog: changelog.md
-  - Credits: credits.md
-  - License: license.md
+- Overview: index.md
 - Usage:
-  - Usage: usage.md
+  - usage.md
+  - Theming: theming.md
   - Handlers:
-    - Overview: handlers/overview.md
+    - handlers/overview.md
     - Python: handlers/python.md
+    - Crystal: https://mkdocstrings.github.io/crystal/
   - Troubleshooting: troubleshooting.md
 - Code Reference:
   - mkdocstrings:
@@ -26,23 +25,23 @@ nav:
   - mkdocs_autorefs:
     - references.py: reference/autorefs/references.md
     - plugin.py: reference/autorefs/plugin.md
-- Development:
-  - Contributing: contributing.md
+- Contributing:
+  - contributing.md
   - Code of Conduct: code_of_conduct.md
   - Coverage report: coverage.md
+- Changelog: changelog.md
+- Credits: credits.md
+- License: license.md
 
 theme:
   name: material
-  features:
-  - navigation.tabs
-  - navigation.expand
   palette:
     scheme: slate
     primary: teal
     accent: purple
 
 extra_css:
-- css/mkdocstrings.css
+- css/style.css
 
 markdown_extensions:
 - admonition
@@ -58,6 +57,7 @@ markdown_extensions:
 
 plugins:
 - search
+- section-index
 - coverage:
     html_report_dir: build/coverage
 - macros:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ description = "Automatic documentation from sources, for MkDocs."
 authors = ["Timothée Mazzucotelli <pawamoy@pm.me>"]
 license = "ISC License"
 readme = "README.md"
-repository = "https://github.com/pawamoy/mkdocstrings"
-homepage = "https://github.com/pawamoy/mkdocstrings"
+repository = "https://github.com/mkdocstrings/mkdocstrings"
+homepage = "https://github.com/mkdocstrings/mkdocstrings"
 keywords = ["mkdocs", "mkdocs-plugin", "docstrings", "autodoc", "documentation"]
 packages = [
     { include = "mkdocstrings", from = "src" },
@@ -42,12 +42,12 @@ flake8-variables-names = "^0.0.4"
 flake8-pytest-style = "^1.3.0"
 git-changelog = "^0.4.2"
 httpx = "^0.16.1"
-
 isort = {version = "^5.7.0", extras = ["pyproject"]}
 jinja2-cli = "^0.7.0"
 mkdocs-coverage = "^0.2.1"
 mkdocs-macros-plugin = "^0.5.0"
 mkdocs-material = "^6.2.7"
+mkdocs-section-index = "^0.2.3"
 mypy = "^0.782"
 pytest = "^6.2.2"
 pytest-cov = "^2.11.1"


### PR DESCRIPTION
* Document more about autorefs, warn about the breaking change.
* Linkify *Features* on the home page.
* Mention Crystal handler (+add CSS for external link).
* Split out a "theming" page from "usage" page.
* Linkify sections via *mkdocs-section-index* plugin.
* Update links after the site has moved into an org.
* Indent some examples into an admonition.
* Change "`mkdocstrings`" and "MkDocstrings" to "*mkdocstrings*".
* Some minor rewordings.