### PR TITLE
tests: Build test sites into a temp directory

### DIFF
--- a/config/flake8.ini
+++ b/config/flake8.ini
@@ -1,0 +1,50 @@
+[flake8]
+exclude = fixtures,docs,site
+max-line-length = 132
+ignore =
+    # we write docstrings in markdown, not rst
+    RST*,
+    # redundant with W0622 (builtin override), which is more precise about line number
+    A001,
+    # missing docstring in magic method
+    D105,
+    # multi-line docstring summary should start at the first line
+    D212,
+    # whitespace before ‘:’ (incompatible with Black)
+    E203,
+    # redundant with E0602 (undefined variable)
+    F821,
+    # black already deals with quoting
+    Q000,
+    # use of assert
+    S101,
+    # we are not parsing XML
+    S405,
+    # line break before binary operator (incompatible with Black)
+    W503,
+    # two-lowercase-letters variable DO conform to snake_case naming style
+    C0103,
+    # redunant with D102 (missing docstring)
+    C0116,
+    # line too long
+    C0301,
+    # too many instance attributes
+    R0902,
+    # too few public methods
+    R0903,
+    # too many public methods
+    R0904,
+    # too many branches
+    R0912,
+    # too many methods
+    R0913,
+    # too many local variables
+    R0914,
+    # too many statements
+    R0915,
+    # redundant with F401 (unused import)
+    W0611,
+    # lazy formatting for logging calls
+    W1203,
+    # short name
+    VNE001

--- a/config/flake8.ini
+++ b/config/flake8.ini
@@ -1,6 +1,7 @@
 [flake8]
 exclude = fixtures,docs,site
 max-line-length = 132
+strictness = long
 ignore =
     # we write docstrings in markdown, not rst
     RST*,

--- a/duties.py
+++ b/duties.py
@@ -159,7 +159,7 @@ def check_code_quality(ctx, files=PY_SRC):
         ctx: The context instance (passed automatically).
         files: The files to check.
     """
-    ctx.run(f"flakehell lint {files}", title="Checking code quality", pty=PTY)
+    ctx.run(f"flake8 --config=config/flake8.ini {files}", title="Checking code quality", pty=PTY)
 
 
 @duty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,37 +80,3 @@ balanced_wrapping = true
 default_section = "THIRDPARTY"
 known_first_party = "mkdocstrings"
 include_trailing_comma = true
-
-[tool.flakehell]
-format = "colored"
-max_line_length = 132
-show_source = false
-exclude = ["tests/fixtures"]
-
-[tool.flakehell.plugins]
-"*" = [
-    "+*",
-    "-RST*",  # we write docstrings in markdown, not rst
-    "-A001",  # redundant with W0622 (builtin override), which is more precise about line number
-    "-D105",  # missing docstring in magic method
-    "-D212",  # multi-line docstring summary should start at the first line
-    "-E203",  # whitespace before ‘:’ (incompatible with Black)
-    "-F821",  # redundant with E0602 (undefined variable)
-    "-Q000",  # black already deals with quoting
-    "-S101",  # use of assert
-    "-S405",  # we are not parsing XML
-    "-W503",  # line break before binary operator (incompatible with Black)
-    "-C0103", # two-lowercase-letters variable DO conform to snake_case naming style
-    "-C0116",  # redunant with D102 (missing docstring)
-    "-C0301",  # line too long
-    "-R0902",  # too many instance attributes
-    "-R0903",  # too few public methods
-    "-R0904",  # too many public methods
-    "-R0912",  # too many branches
-    "-R0913",  # too many methods
-    "-R0914",  # too many local variables
-    "-R0915",  # too many statements
-    "-W0611",  # redundant with F401 (unused import)
-    "-W1203",  # lazy formatting for logging calls
-    "-VNE001",  # short name
-]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -8,6 +8,8 @@ from mkdocs.config.base import load_config
 
 
 @pytest.mark.xfail(sys.version.startswith("3.9"), reason="pytkdocs is failing on Python 3.9")
-def test_plugin():
+def test_plugin(tmp_path):
     """Build our own documentation."""
-    build(load_config())
+    config = load_config()
+    config["site_dir"] = tmp_path
+    build(config)


### PR DESCRIPTION
## chore: Migrate from flakehell to flake8
  
  Flakehell is abandoned, I personally ran into problems with its faulty lingering cache, and now it's preventing me from configuring darglint.


## tests: Build test sites into a temp directory

  This was causing random test failures because multiple tests concurrently try to delete and re-create the same site dir.
  Refactor to use pytest fixtures instead while on it.

  Bonus: allow docstrings to not specify Arguments sections etc. But if they are specified, they will still be checked.
  Here because it's ridiculous to document fixtures in every test function. Generally because sometimes all args are obvious if it's just an override.

