### PR TITLE
fix: Don't double-escape characters in highlighted headings

### DIFF
--- a/src/mkdocstrings/handlers/rendering.py
+++ b/src/mkdocstrings/handlers/rendering.py
@@ -62,6 +62,8 @@ class Highlighter(Highlight):
         Returns:
             The highlighted code as HTML text, marked safe (not escaped for HTML).
         """
+        if isinstance(src, Markup):
+            src = src.unescape()
         if dedent:
             src = textwrap.dedent(src)
 

--- a/tests/fixtures/string_annotation.py
+++ b/tests/fixtures/string_annotation.py
@@ -1,0 +1,8 @@
+from typing import Literal
+
+
+class Foo:
+    @property
+    def foo() -> Literal["hi"]:
+        "hi"
+        return "hi"

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,4 +1,5 @@
 """Tests for the extension module."""
+import sys
 from collections import ChainMap
 from textwrap import dedent
 
@@ -83,6 +84,14 @@ def test_reference_inside_autodoc(ext_markdown):
     output = ext_markdown.convert("::: tests.fixtures.cross_reference")
     snippet = 'Link to <span data-mkdocstrings-identifier="something.Else">something.Else</span>.'
     assert snippet in output
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="typing.Literal requires Python 3.8")
+def test_quote_inside_annotation(ext_markdown):
+    """Assert that inline highlighting doesn't double-escape HTML."""
+    output = ext_markdown.convert("::: tests.fixtures.string_annotation.Foo")
+    assert ";hi&" in output
+    assert "&amp;" not in output
 
 
 def test_html_inside_heading(ext_markdown):


### PR DESCRIPTION
Fixes #228﻿
