### PR TITLE
allow printing collector process stderr to system

### DIFF
--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -152,7 +152,6 @@ class PythonCollector(BaseCollector):
         self.process = Popen(  # noqa: S603,S607 (we trust the input, and we don't want to use the absolute path)
             cmd,
             universal_newlines=True,
-            stderr=PIPE,
             stdout=PIPE,
             stdin=PIPE,
             bufsize=-1,


### PR DESCRIPTION
There seems to be no problem in propagating the `stderr` outwards, and without this there is no feedback as to what went wrong in the `step_commands`.