### PR TITLE
fix: Fix custom handler not being used

### DIFF
--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -343,10 +343,10 @@ class Handlers:
         Returns:
             The name of the handler to use.
         """
-        config = self._config["mkdocstrings"]
+        global_config = self._config["mkdocstrings"]
         if "handler" in config:
             return config["handler"]
-        return config["default_handler"]
+        return global_config["default_handler"]
 
     def get_handler_config(self, name: str) -> dict:
         """Return the global configuration of the given handler.

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -152,3 +152,9 @@ def test_no_double_toc(ext_markdown, expect_permalink):
         },
         {"level": 1, "id": "bb", "name": "bb", "children": []},
     ]
+
+
+def test_use_custom_handler(ext_markdown):
+    """Assert that we use the custom handler declared in an individual autodoc instruction."""
+    with pytest.raises(ModuleNotFoundError):
+        ext_markdown.convert("::: tests.fixtures.headings\n    handler: not_here")


### PR DESCRIPTION
Custom handlers configured in individual
autodoc instructions were not picked up
by mkdocstrings.

Issue #259