### PR TITLE
feat: Very basic support for MkDocs theme

### DIFF
--- a/src/mkdocstrings/templates/python/material/attributes.html
+++ b/src/mkdocstrings/templates/python/material/attributes.html
@@ -12,7 +12,7 @@
     {% for attribute in attributes %}
       <tr>
         <td><code>{{ attribute.name }}</code></td>
-        <td><code>{{ attribute.annotation }}</code></td>
+        <td>{% if attribute.annotation %}<code>{{ attribute.annotation }}</code>{% endif %}</td>
         <td>{{ attribute.description|convert_markdown(heading_level, html_id) }}</td>
       </tr>
     {% endfor %}

--- a/src/mkdocstrings/templates/python/material/parameters.html
+++ b/src/mkdocstrings/templates/python/material/parameters.html
@@ -13,7 +13,7 @@
     {% for parameter in parameters %}
       <tr>
         <td><code>{{ parameter.name }}</code></td>
-        <td><code>{{ parameter.annotation }}</code></td>
+        <td>{% if parameter.annotation %}<code>{{ parameter.annotation }}</code>{% endif %}</td>
         <td>{{ parameter.description|convert_markdown(heading_level, html_id) }}</td>
         <td>{% if parameter.default %}<code>{{ parameter.default }}</code>{% else %}<em>required</em>{% endif %}</td>
       </tr>

--- a/src/mkdocstrings/templates/python/material/return.html
+++ b/src/mkdocstrings/templates/python/material/return.html
@@ -9,7 +9,7 @@
   </thead>
   <tbody>
     <tr>
-      <td><code>{{ return.annotation }}</code></td>
+      <td>{% if return.annotation %}<code>{{ return.annotation }}</code>{% endif %}</td>
       <td>{{ return.description|convert_markdown(heading_level, html_id) }}</td>
     </tr>
   </tbody>

--- a/src/mkdocstrings/templates/python/mkdocs/exceptions.html
+++ b/src/mkdocstrings/templates/python/mkdocs/exceptions.html
@@ -1,0 +1,7 @@
+{{ log.debug() }}
+<dl>
+  <dt>Exceptions:</th>
+  {% for exception in exceptions %}
+    <dd>{{ ("`" + exception.annotation + "`: " + exception.description)|convert_markdown(heading_level, html_id) }}</dd>
+  {% endfor %}
+</dl>

--- a/src/mkdocstrings/templates/python/mkdocs/parameters.html
+++ b/src/mkdocstrings/templates/python/mkdocs/parameters.html
@@ -1,0 +1,7 @@
+{{ log.debug() }}
+<dl>
+  <dt>Parameters:</th>
+  {% for parameter in parameters %}
+    <dd>{{ ("**" + parameter.name + ":** " + ("`" + parameter.annotation + "` – " if parameter.annotation else "") + parameter.description)|convert_markdown(heading_level, html_id) }}</dd>
+  {% endfor %}
+</dl>

--- a/src/mkdocstrings/templates/python/mkdocs/return.html
+++ b/src/mkdocstrings/templates/python/mkdocs/return.html
@@ -1,0 +1,5 @@
+{{ log.debug() }}
+<dl>
+    <dt>Returns:</th>
+    <dd>{{ (("`" + return.annotation + "` – " if return.annotation else "") + return.description)|convert_markdown(heading_level, html_id) }}</dd>
+</dl>

--- a/src/mkdocstrings/templates/python/mkdocs/style.css
+++ b/src/mkdocstrings/templates/python/mkdocs/style.css
@@ -1,0 +1,11 @@
+.doc-contents {
+  padding-left: 20px;
+}
+
+.doc-contents dd>p {
+  margin-bottom: 0.5rem;
+}
+
+.doc-contents dl+dl {
+  margin-top: -0.5rem;
+}

--- a/src/mkdocstrings/templates/python/readthedocs/parameters.html
+++ b/src/mkdocstrings/templates/python/readthedocs/parameters.html
@@ -10,7 +10,7 @@
       <td class="field-body">
         <ul class="first simple">
           {% for parameter in parameters %}
-            <li>{{ ("**" + parameter.name + "** (`" + parameter.annotation + "`) – " + parameter.description)|convert_markdown(heading_level, html_id) }}</li>
+            <li>{{ ("**" + parameter.name + "**" + (" (`" + parameter.annotation + "`)" if parameter.annotation else "") + " – " + parameter.description)|convert_markdown(heading_level, html_id) }}</li>
           {% endfor %}
         </ul>
       </td>

--- a/src/mkdocstrings/templates/python/readthedocs/return.html
+++ b/src/mkdocstrings/templates/python/readthedocs/return.html
@@ -9,7 +9,7 @@
     <th class="field-name">Returns:</th>
     <td class="field-body">
         <ul class="first simple">
-          <li>{{ ("`" + return.annotation + "` – " + return.description)|convert_markdown(heading_level, html_id) }}</li>
+          <li>{{ (("`" + return.annotation + "` – ") if return.annotation else "") + return.description)|convert_markdown(heading_level, html_id) }}</li>
         </ul>
     </td>
     </tr>


### PR DESCRIPTION
*    fix: Don't render empty code blocks for missing type annotations
*    feat: Very basic support for MkDocs theme
    It mimicks the look and the elements applied on this page: https://www.mkdocs.org/user-guide/plugins/

