### PR TITLE
feat: Add a rendering option to change the sorting of members

### DIFF
--- a/docs/reference/autorefs/plugin.md
+++ b/docs/reference/autorefs/plugin.md
@@ -1,3 +1,1 @@
 ::: mkdocs_autorefs.plugin
-    rendering:
-      members_order: source

--- a/docs/reference/autorefs/plugin.md
+++ b/docs/reference/autorefs/plugin.md
@@ -1,1 +1,3 @@
 ::: mkdocs_autorefs.plugin
+    rendering:
+      sort_members: source

--- a/docs/reference/autorefs/plugin.md
+++ b/docs/reference/autorefs/plugin.md
@@ -1,3 +1,3 @@
 ::: mkdocs_autorefs.plugin
     rendering:
-      sort_members: source
+      members_order: source

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -18,6 +18,7 @@ from markupsafe import Markup
 from mkdocstrings.handlers.base import BaseCollector, BaseHandler, BaseRenderer, CollectionError, CollectorItem
 from mkdocstrings.inventory import Inventory
 from mkdocstrings.loggers import get_logger
+from mkdocstrings.extension import PluginError
 
 log = get_logger(__name__)
 
@@ -346,7 +347,7 @@ def sort_object(obj: CollectorItem, sort_style: str) -> None:
         elif sort_style == "source":
             return a.get("source", {}).get("line_start", 0)
         else:
-            raise Exception("unknown sort_style")
+            raise PluginError("unknown sort_style")
 
     obj["children"].sort(key=sort_key)
 

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -49,7 +49,7 @@ class PythonRenderer(BaseRenderer):
         "show_bases": True,
         "group_by_category": True,
         "heading_level": 2,
-        "sort_members": "lexical",
+        "members_order": "alphabetical",
     }
     """The default rendering options.
 
@@ -67,7 +67,7 @@ class PythonRenderer(BaseRenderer):
     **`show_bases`** | `bool` | Show the base classes of a class. | `True`
     **`group_by_category`** | `bool` | Group the object's children by categories: attributes, classes, functions, methods, and modules. | `True`
     **`heading_level`** | `int` | The initial heading level to use. | `2`
-    **`sort_members`** | `str` | The sort option to use. Options: `lexical` - order by the member name, `source` - order members as they appear in the source file | `lexical`
+    **`members_order`** | `str` | The sort option to use. Options: `alphabetical` - order by the member name, `source` - order members as they appear in the source file | `alphabetical`
     """  # noqa: E501
 
     def render(self, data: CollectorItem, config: dict) -> str:  # noqa: D102 (ignore missing docstring)
@@ -80,7 +80,7 @@ class PythonRenderer(BaseRenderer):
         # than as an item in a dictionary.
         heading_level = final_config["heading_level"]
 
-        sort_object(data, sort_style=final_config["sort_members"])
+        sort_object(data, sort_style=final_config["members_order"])
 
         return template.render(
             **{"config": final_config, data["category"]: data, "heading_level": heading_level, "root": True},
@@ -337,11 +337,11 @@ def sort_object(obj: CollectorItem, sort_style: str) -> None:
 
     Arguments:
         obj: The collected object, as a dict. Note that this argument is mutated.
-        sort_style: How to sort the children lists - 'lexical' or 'source'.
+        sort_style: How to sort the children lists - 'alphabetical' or 'source'.
     """
 
     def sort_key(a: dict) -> Any:
-        if sort_style == "lexical":
+        if sort_style == "alphabetical":
             return a.get("name")
         elif sort_style == "source":
             return a.get("source", {}).get("line_start", 0)

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -87,7 +87,7 @@ class PythonRenderer(BaseRenderer):
         elif members_order == "source":
             sort_function = _sort_key_source
         else:
-            raise PluginError("unknown members_order")
+            raise PluginError(f"Unknown members_order '{members_order}', choose between 'alphabetical' and 'source'.")
 
         sort_object(data, sort_function=sort_function)
 

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -362,5 +362,5 @@ def _sort_key_alphabetical(item: CollectorItem) -> Any:
 
 
 def _sort_key_source(item: CollectorItem) -> Any:
-    """Returns a sort key for 'source' sorting of CollectorItems"""
+    """Return a sort key for 'source' sorting of CollectorItems."""
     return item.get("source", {}).get("line_start", 0)

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -341,18 +341,21 @@ def sort_object(obj: CollectorItem, sort_style: str) -> None:
         sort_style: How to sort the children lists - 'alphabetical' or 'source'.
     """
 
-    def sort_key(a: dict) -> Any:
-        if sort_style == "alphabetical":
-            return a.get("name")
-        elif sort_style == "source":
-            return a.get("source", {}).get("line_start", 0)
-        else:
-            raise PluginError("unknown sort_style")
+    if sort_style == "alphabetical":
+        # sort_last is a string that contains the final unicode character, so
+        # if 'name' isn't found on the object, the item will go to the end of
+        # the list.
+        sort_last = chr(sys.maxunicode)
+        sort_function = lambda item: item.get("name", sort_last)
+    elif sort_style == "source":
+        sort_function = lambda item: item.get("source", {}).get("line_start", 0)
+    else:
+        raise PluginError('unknown sort_style')
 
-    obj["children"].sort(key=sort_key)
+    obj["children"].sort(key=sort_function)
 
     for category in ("attributes", "classes", "functions", "methods", "modules"):
-        obj[category].sort(key=sort_key)
+        obj[category].sort(key=sort_function)
 
     for child in obj["children"]:
         sort_object(child, sort_style=sort_style)

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -68,7 +68,7 @@ class PythonRenderer(BaseRenderer):
     **`show_bases`** | `bool` | Show the base classes of a class. | `True`
     **`group_by_category`** | `bool` | Group the object's children by categories: attributes, classes, functions, methods, and modules. | `True`
     **`heading_level`** | `int` | The initial heading level to use. | `2`
-    **`members_order`** | `str` | The sort option to use. Options: `alphabetical` - order by the member name, `source` - order members as they appear in the source file | `alphabetical`
+    **`members_order`** | `str` | The members ordering to use. Options: `alphabetical` - order by the members names, `source` - order members as they appear in the source file. | `alphabetical`
     """  # noqa: E501
 
     def render(self, data: CollectorItem, config: dict) -> str:  # noqa: D102 (ignore missing docstring)

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -15,10 +15,10 @@ from typing import Any, BinaryIO, Callable, Iterator, List, Optional, Tuple
 from markdown import Markdown
 from markupsafe import Markup
 
+from mkdocstrings.extension import PluginError
 from mkdocstrings.handlers.base import BaseCollector, BaseHandler, BaseRenderer, CollectionError, CollectorItem
 from mkdocstrings.inventory import Inventory
 from mkdocstrings.loggers import get_logger
-from mkdocstrings.extension import PluginError
 
 log = get_logger(__name__)
 
@@ -174,7 +174,12 @@ class PythonCollector(BaseCollector):
             cmd = [sys.executable, "-m", "pytkdocs", "--line-by-line"]
 
         self.process = Popen(  # noqa: S603,S607 (we trust the input, and we don't want to use the absolute path)
-            cmd, universal_newlines=True, stdout=PIPE, stdin=PIPE, bufsize=-1, env=env,
+            cmd,
+            universal_newlines=True,
+            stdout=PIPE,
+            stdin=PIPE,
+            bufsize=-1,
+            env=env,
         )
 
     def collect(self, identifier: str, config: dict) -> CollectorItem:

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -354,7 +354,7 @@ def sort_object(obj: CollectorItem, sort_function: Callable[[CollectorItem], Any
 
 
 def _sort_key_alphabetical(item: CollectorItem) -> Any:
-    """Returns a sort key for 'alphabetical' sorting of CollectorItems"""
+    """Return a sort key for 'alphabetical' sorting of CollectorItems."""
     # chr(sys.maxunicode) is a string that contains the final unicode
     # character, so if 'name' isn't found on the object, the item will go to
     # the end of the list.

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -348,7 +348,6 @@ def sort_object(obj: CollectorItem, sort_function: Callable[[CollectorItem], Any
         obj: The collected object, as a dict. Note that this argument is mutated.
         sort_function: The sort key function used to determine the order of elements.
     """
-
     obj["children"].sort(key=sort_function)
 
     for category in ("attributes", "classes", "functions", "methods", "modules"):
@@ -368,4 +367,6 @@ def _sort_key_alphabetical(item: CollectorItem) -> Any:
 
 def _sort_key_source(item: CollectorItem) -> Any:
     """Return a sort key for 'source' sorting of CollectorItems."""
-    return item.get("source", {}).get("line_start", 0)
+    # if 'line_start' isn't found on the object, the item will go to
+    # the start of the list.
+    return item.get("source", {}).get("line_start", -1)

--- a/src/mkdocstrings/templates/python/material/children.html
+++ b/src/mkdocstrings/templates/python/material/children.html
@@ -17,7 +17,7 @@
           {% filter heading(heading_level, id=html_id ~ "-attributes") %}Attributes{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
-          {% for attribute in obj.attributes|sort(attribute="name") %}
+          {% for attribute in obj.attributes %}
             {% include "attribute.html" with context %}
           {% endfor %}
         {% endwith %}
@@ -26,7 +26,7 @@
           {% filter heading(heading_level, id=html_id ~ "-classes") %}Classes{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
-          {% for class in obj.classes|sort(attribute="name") %}
+          {% for class in obj.classes %}
             {% include "class.html" with context %}
           {% endfor %}
         {% endwith %}
@@ -35,7 +35,7 @@
           {% filter heading(heading_level, id=html_id ~ "-functions") %}Functions{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
-          {% for function in obj.functions|sort(attribute="name") %}
+          {% for function in obj.functions %}
             {% include "function.html" with context %}
           {% endfor %}
         {% endwith %}
@@ -44,7 +44,7 @@
           {% filter heading(heading_level, id=html_id ~ "-methods") %}Methods{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
-          {% for method in obj.methods|sort(attribute="name") %}
+          {% for method in obj.methods %}
             {% include "method.html" with context %}
           {% endfor %}
         {% endwith %}
@@ -53,7 +53,7 @@
           {% filter heading(heading_level, id=html_id ~ "-modules") %}Modules{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
-          {% for module in obj.modules|sort(attribute="name") %}
+          {% for module in obj.modules %}
             {% include "module.html" with context %}
           {% endfor %}
         {% endwith %}
@@ -62,7 +62,7 @@
 
     {% else %}
 
-      {% for child in obj.children|sort(attribute="name") %}
+      {% for child in obj.children %}
         {% if child.category == "attribute" %}
           {% with attribute = child %}
             {% include "attribute.html" with context %}

--- a/tests/test_python_handler.py
+++ b/tests/test_python_handler.py
@@ -1,0 +1,66 @@
+"""Tests for the handlers.python module."""
+
+from mkdocstrings.handlers.python import _sort_key_alphabetical, _sort_key_source, sort_object
+
+
+def test_members_order():
+    """Assert that members sorting functions work correctly."""
+    collected = {
+        key: [
+            {"name": "z", "source": {"line_start": 100}},
+            {"name": "b", "source": {"line_start": 0}},
+            {"source": {"line_start": 10}},
+            {"name": "a"},
+            {
+                "name": "c",
+                "source": {"line_start": 30},
+                "children": [
+                    {
+                        {"name": "z", "source": {"line_start": 200}},
+                        {"name": "a", "source": {"line_start": 20}},
+                    }
+                ],
+            },
+        ]
+        for key in ("children", "attributes", "classes", "functions", "methods", "modules")
+    }
+
+    alphebetical = sort_object(collected, _sort_key_alphabetical)
+
+    for category in ("children", "attributes", "classes", "functions", "methods", "modules"):
+        assert alphebetical[category] == [
+            {"name": "a"},
+            {"name": "b", "source": {"line_start": 0}},
+            {
+                "name": "c",
+                "source": {"line_start": 30},
+                "children": [
+                    {
+                        {"name": "a", "source": {"line_start": 20}},
+                        {"name": "z", "source": {"line_start": 200}},
+                    }
+                ],
+            },
+            {"name": "z", "source": {"line_start": 100}},
+            {"source": {"line_start": 10}},
+        ]
+
+    source = sort_object(collected, _sort_key_source)
+
+    for category in ("children", "attributes", "classes", "functions", "methods", "modules"):
+        assert source[category] == [
+            {"name": "a"},
+            {"name": "b", "source": {"line_start": 0}},
+            {"source": {"line_start": 10}},
+            {
+                "name": "c",
+                "source": {"line_start": 30},
+                "children": [
+                    {
+                        {"name": "a", "source": {"line_start": 20}},
+                        {"name": "z", "source": {"line_start": 200}},
+                    }
+                ],
+            },
+            {"name": "z", "source": {"line_start": 100}},
+        ]


### PR DESCRIPTION
Hey! I developed this feature for my own use but figured it could be useful for others too. I wanted to make the members of a class appear as they do in the source file, instead of sorting them alphabetically. So I added this option. It works like:

```yaml
::: mkdocs_autorefs.plugin
    rendering:
      sort_members: source
```

'lexical' is the default, 'source' sets the order to that in the source file. It works by pulling the sort behaviour out of the template, and into the PythonRenderer.

This might be related to #102? Or maybe not.