### PR TITLE
feat: Support loading external inventories and linking to them

### DIFF
--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -289,6 +289,7 @@ class MkdocstringsPlugin(BasePlugin):
         with urllib.request.urlopen(req) as resp:  # noqa: S310 (URL audit OK: comes from a checked-in config)
             if "gzip" in resp.headers.get("content-encoding", ""):
                 resp = gzip.GzipFile(fileobj=resp)
-            result = dict(loader(resp, url=url))
+            items = loader(resp, url=url)  # type: ignore
+            result = dict(items)
         log.debug(f"Loaded inventory from {url!r}: {len(result)} items")
         return result

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -235,6 +235,7 @@ class MkdocstringsPlugin(BasePlugin):
                 write_file(inv_contents, os.path.join(config["site_dir"], "objects.inv"))
 
         if self._inv_futures:
+            log.debug(f"Waiting for {len(self._inv_futures)} inventory download(s)")
             concurrent.futures.wait(self._inv_futures, timeout=30)
             for k, v in collections.ChainMap(*(f.result() for f in self._inv_futures)).items():
                 config["plugins"]["autorefs"].register_url(k, v)


### PR DESCRIPTION
Example of how an external handler can be implemented:

* https://github.com/mkdocstrings/crystal/compare/inv#commit_comments_bucket

* ```yaml
  plugins:
  - mkdocstrings:
      handlers:
        crystal:
          import:
            - https://crystal-lang.org/api/latest/index.json
  ```

Alternative to https://github.com/mkdocstrings/autorefs/pull/4