### PR TITLE
build: Looks like we're ready for the upcoming major Jinja release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ packages = [ { include = "mkdocstrings", from = "src" } ]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-Jinja2 = "^2.11.1, <4.0"
+Jinja2 = ">=2.11.1, <4.0"
 Markdown = "^3.3"
 MarkupSafe = ">=1.1, <3.0"
 mkdocs = "^1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ packages = [ { include = "mkdocstrings", from = "src" } ]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-Jinja2 = "^2.11"
+Jinja2 = "^2.11.1, <4.0"
 Markdown = "^3.3"
-MarkupSafe = "^1.1"
+MarkupSafe = ">=1.1, <3.0"
 mkdocs = "^1.1"
 mkdocs-autorefs = ">=0.1, <0.3"
 pymdown-extensions = ">=6.3, <9.0"


### PR DESCRIPTION
and same for MarkupSafe.

They mainly just drop Python 2.
* https://jinja.palletsprojects.com/en/master/changes/#version-3-0-0
* https://markupsafe.palletsprojects.com/en/master/changes/#version-2-0-0
