### PR TITLE
feat: Support loading external Python inventories in Sphinx format

### DIFF
--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -5,6 +5,7 @@ The handler collects data with [`pytkdocs`](https://github.com/pawamoy/pytkdocs)
 
 import json
 import os
+import posixpath
 import sys
 import traceback
 from collections import ChainMap
@@ -14,6 +15,7 @@ from typing import Any, List, Optional
 from markdown import Markdown
 
 from mkdocstrings.handlers.base import BaseCollector, BaseHandler, BaseRenderer, CollectionError, CollectorItem
+from mkdocstrings.inventory import Inventory
 from mkdocstrings.loggers import get_logger
 
 log = get_logger(__name__)
@@ -245,6 +247,14 @@ class PythonHandler(BaseHandler):
 
     domain: str = "py"  # to match Sphinx's default domain
     enable_inventory: bool = True
+
+    @classmethod
+    def load_inventory(cls, file, url, base_url=None, **kwargs):
+        if base_url is None:
+            base_url = posixpath.dirname(url)
+
+        for item in Inventory.parse_sphinx(file, domain_filter="py:").values():
+            yield item.name, posixpath.join(base_url, item.uri)
 
 
 def get_handler(

--- a/src/mkdocstrings/inventory.py
+++ b/src/mkdocstrings/inventory.py
@@ -46,12 +46,12 @@ class InventoryItem:
             uri = uri[: -len(self.name)] + "$"
         return f"{self.name} {self.domain}:{self.role} {self.priority} {uri} {dispname}"
 
-    regex = re.compile(r"^(.+?)\s+(\S+):(\S+)\s+(-?\d+)\s+(\S+)\s+(.*)$")
+    sphinx_item_regex = re.compile(r"^(.+?)\s+(\S+):(\S+)\s+(-?\d+)\s+(\S+)\s+(.*)$")
 
     @classmethod
     def parse_sphinx(cls, line: str) -> "InventoryItem":
         """Parse a line from a Sphinx v2 inventory file and return an `InventoryItem` from it."""
-        m = cls.regex.search(line)
+        m = cls.sphinx_item_regex.search(line)
         if not m:
             raise ValueError(line)
         name, domain, role, priority, uri, dispname = m.groups()

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -289,7 +289,7 @@ class MkdocstringsPlugin(BasePlugin):
             A mapping from identifier to absolute URL.
         """
         log.debug(f"Downloading inventory from {url!r}")
-        req = urllib.request.Request(url, headers={"Accept-Encoding": "gzip"})
+        req = urllib.request.Request(url, headers={"Accept-Encoding": "gzip", "User-Agent": "mkdocstrings/0.15.0"})
         with urllib.request.urlopen(req) as resp:  # noqa: S310 (URL audit OK: comes from a checked-in config)
             content: BinaryIO = resp
             if "gzip" in resp.headers.get("content-encoding", ""):


### PR DESCRIPTION
\+ small refactors in InventoryItem


Completely random example of how this is used:

```diff
diff --git a/docs/usage.md b/docs/usage.md
index ce8c0bef7..9c69459bd 100644
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,3 +1,5 @@
+[github.Topic.Topic.created_at][]
+
 # Usage
 
 ## Autodoc syntax
diff --git a/mkdocs.yml b/mkdocs.yml
index f3cbe2778..9d40b3108 100644
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,5 +46,7 @@ plugins:
         - sys.path.append("docs")
         selection:
           new_path_syntax: yes
+        import:
+        - https://pygithub.readthedocs.io/en/latest/objects.inv
     watch:
     - src/mkdocstrings
```