### PR TITLE
Optionally show base classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ Jinja2 = ">=2.11.1, <4.0"
 Markdown = "^3.3"
 MarkupSafe = ">=1.1, <3.0"
 mkdocs = "^1.1.1"
-mkdocs-autorefs = ">=0.1, <0.3"
+mkdocs-autorefs = ">=0.1, <0.4"
 pymdown-extensions = ">=6.3, <9.0"
 pytkdocs = ">=0.2.0, <0.12.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ MarkupSafe = ">=1.1, <3.0"
 mkdocs = "^1.1.1"
 mkdocs-autorefs = ">=0.1, <0.4"
 pymdown-extensions = ">=6.3, <9.0"
-pytkdocs = ">=0.2.0, <0.12.0"
+pytkdocs = ">=0.2.0, <0.13.0"
 
 [tool.poetry.dev-dependencies]
 # formatting, quality, tests

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -13,6 +13,7 @@ from subprocess import PIPE, Popen  # noqa: S404 (what other option, more secure
 from typing import Any, BinaryIO, Iterator, List, Optional, Tuple
 
 from markdown import Markdown
+from markupsafe import Markup
 
 from mkdocstrings.handlers.base import BaseCollector, BaseHandler, BaseRenderer, CollectionError, CollectorItem
 from mkdocstrings.inventory import Inventory
@@ -45,6 +46,7 @@ class PythonRenderer(BaseRenderer):
         "show_if_no_docstring": False,
         "show_signature_annotations": False,
         "show_source": True,
+        "show_bases": True,
         "group_by_category": True,
         "heading_level": 2,
     }
@@ -61,6 +63,7 @@ class PythonRenderer(BaseRenderer):
     **`show_if_no_docstring`** | `bool` | Show the object heading even if it has no docstring or children with docstrings. | `False`
     **`show_signature_annotations`** | `bool` | Show the type annotations in methods and functions signatures. | `False`
     **`show_source`** | `bool` | Show the source code of this object. | `True`
+    **`show_bases`** | `bool` | Show the base classes of a class. | `True`
     **`group_by_category`** | `bool` | Group the object's children by categories: attributes, classes, functions, methods, and modules. | `True`
     **`heading_level`** | `int` | The initial heading level to use. | `2`
     """  # noqa: E501
@@ -87,6 +90,12 @@ class PythonRenderer(BaseRenderer):
         self.env.trim_blocks = True
         self.env.lstrip_blocks = True
         self.env.keep_trailing_newline = False
+        self.env.filters["brief_xref"] = self.do_brief_xref
+
+    def do_brief_xref(self, path: str) -> Markup:
+        """Filter to create cross-reference with brief text and full identifier as hover text."""
+        brief = path.split(".")[-1]
+        return Markup("<span data-autorefs-optional-hover={path}>{brief}</span>").format(path=path, brief=brief)
 
 
 class PythonCollector(BaseCollector):

--- a/src/mkdocstrings/templates/python/material/class.html
+++ b/src/mkdocstrings/templates/python/material/class.html
@@ -22,7 +22,14 @@
           class="doc doc-heading",
           toc_label=class.name) %}
 
-        <code>{% if show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif %}</code>
+        <code>
+          {% if show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif %}
+          {% if config.show_bases and class.bases != ['object'] %}
+            ({% for base in class.bases -%}
+              {{ base|brief_xref() }}{% if not loop.last %}, {% endif %}
+             {% endfor %})
+          {% endif %}
+        </code>
 
         {% with properties = class.properties %}
           {% include "properties.html" with context %}


### PR DESCRIPTION
I'm not sure if this is the best way to present them, or if it should be on by default.  Feedback welcome.

Fixes https://github.com/mkdocstrings/mkdocstrings/issues/269
Requires https://github.com/mkdocstrings/pytkdocs/pull/108
Best with https://github.com/mkdocstrings/autorefs/pull/10 so that you can hover over a base class to see the fully qualified name

Screenshot:

![shot](https://user-images.githubusercontent.com/2101303/122655839-89fefe00-d10a-11eb-9d99-d867d29ebe03.png)
