### PR TITLE
docs: More bottom space

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -17,6 +17,6 @@ a.external:hover::after, a.md-nav__link[href^="https:"]:hover::after {
 }
 
 /* More space at the bottom of the page */
-.md-footer {
-  margin-top: 1.5rem;
+.md-main__inner {
+  margin-bottom: 1.5rem;
 }


### PR DESCRIPTION
By default, there is few space at the bottom of the page, this PR sets it equal to the top space.

### Before

![bildo](https://user-images.githubusercontent.com/39555268/131023670-f20d1cda-bf4a-4273-80e1-3d35d7f80581.png)

### After

![bildo](https://user-images.githubusercontent.com/39555268/131024276-7108fb46-9559-4f2d-a7b5-bcc1871deea3.png)
