### PR TITLE
refactor: Don't add parentheses when class has no bases

### DIFF
--- a/src/mkdocstrings/templates/python/material/class.html
+++ b/src/mkdocstrings/templates/python/material/class.html
@@ -24,7 +24,7 @@
 
         <code>
           {% if show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif %}
-          {% if config.show_bases and class.bases != ['object'] %}
+          {% if config.show_bases and class.bases and class.bases != ['object'] %}
             ({% for base in class.bases -%}
               {{ base|brief_xref() }}{% if not loop.last %}, {% endif %}
              {% endfor %})


### PR DESCRIPTION
This happens when pytkdocs is not in version 0.12.
This change therefore supports versions before 0.12.