### PR TITLE
refactor: Return multiple identifiers from fallback method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,13 @@ build-backend = "pdm.pep517.api"
 
 [project]
 name = "mkdocstrings"
-version = {use_scm = true}
 description = "Automatic documentation from sources, for MkDocs."
 authors = [{name = "Timothée Mazzucotelli", email = "pawamoy@pm.me"}]
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.6.1"
 keywords = ["mkdocs", "mkdocs-plugin", "docstrings", "autodoc", "documentation"]
-dynamic = ["version", "classifiers"]
+dynamic = ["version"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: ISC License (ISCL)",
@@ -45,6 +44,7 @@ mkdocstrings = "mkdocstrings.plugin:MkdocstringsPlugin"
 [tool.pdm]
 package-dir = "src"
 includes = ["src/mkdocstrings"]
+version = {use_scm = true}
 
 [tool.pdm.dev-dependencies]
 duty = ["duty~=0.6"]

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -125,18 +125,20 @@ class BaseRenderer(ABC):
             The rendered template as HTML.
         """  # noqa: DAR202 (excess return section)
 
-    def get_anchor(self, data: CollectorItem) -> Optional[str]:
-        """Return the canonical identifier (HTML anchor) for a collected item.
-
-        This must match what the renderer would've actually rendered,
-        e.g. if rendering the item contains `<h2 id="foo">...` then the return value should be "foo".
+    def get_anchors(self, data: CollectorItem) -> Sequence[str]:
+        """Return the possible identifiers (HTML anchors) for a collected item.
 
         Arguments:
             data: The collected data.
 
         Returns:
-            The HTML anchor (without '#') as a string, or None if this item doesn't have an anchor.
-        """  # noqa: DAR202 (excess return section)
+            The HTML anchors (without '#'), or an empty tuple if this item doesn't have an anchor.
+        """
+        # TODO: remove this at some point
+        try:
+            return (self.get_anchor(data),)  # type: ignore
+        except AttributeError:
+            return ()
 
     def do_convert_markdown(self, text: str, heading_level: int, html_id: str = "") -> Markup:
         """Render Markdown text; for use inside templates.
@@ -329,24 +331,24 @@ class Handlers:
         self._handlers: Dict[str, BaseHandler] = {}
         self.inventory: Inventory = Inventory(project=self._config["site_name"])
 
-    def get_anchor(self, identifier: str) -> Optional[str]:
+    def get_anchors(self, identifier: str) -> Sequence[str]:
         """Return the canonical HTML anchor for the identifier, if any of the seen handlers can collect it.
 
         Arguments:
             identifier: The identifier (one that [collect][mkdocstrings.handlers.base.BaseCollector.collect] can accept).
 
         Returns:
-            A string - anchor without '#', or None if there isn't any identifier familiar with it.
+            A tuple of strings - anchors without '#', or an empty tuple if there isn't any identifier familiar with it.
         """
         for handler in self._handlers.values():
             fallback_config = getattr(handler.collector, "fallback_config", {})
             try:
-                anchor = handler.renderer.get_anchor(handler.collector.collect(identifier, fallback_config))
+                anchors = handler.renderer.get_anchors(handler.collector.collect(identifier, fallback_config))
             except CollectionError:
                 continue
-            if anchor is not None:
-                return anchor
-        return None
+            if anchors:
+                return anchors
+        return ()
 
     def get_handler_name(self, config: dict) -> str:
         """Return the handler name defined in an "autodoc" instruction YAML configuration, or the global default handler.

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -10,7 +10,7 @@ import sys
 import traceback
 from collections import ChainMap
 from subprocess import PIPE, Popen  # noqa: S404 (what other option, more secure that PIPE do we have? sockets?)
-from typing import Any, BinaryIO, Callable, Iterator, List, Optional, Tuple
+from typing import Any, BinaryIO, Callable, Iterator, List, Optional, Sequence, Tuple
 
 from markdown import Markdown
 from markupsafe import Markup
@@ -95,8 +95,11 @@ class PythonRenderer(BaseRenderer):
             **{"config": final_config, data["category"]: data, "heading_level": heading_level, "root": True},
         )
 
-    def get_anchor(self, data: CollectorItem) -> str:  # noqa: D102 (ignore missing docstring)
-        return data.get("path")
+    def get_anchors(self, data: CollectorItem) -> Sequence[str]:  # noqa: D102 (ignore missing docstring)
+        try:
+            return (data["path"],)
+        except KeyError:
+            return ()
 
     def update_env(self, md: Markdown, config: dict) -> None:  # noqa: D102 (ignore missing docstring)
         super().update_env(md, config)
@@ -144,7 +147,7 @@ class PythonCollector(BaseCollector):
     fallback_config = {"docstring_style": "markdown", "filters": ["!.*"]}
     """The configuration used when falling back to re-collecting an object to get its anchor.
 
-    This configuration is used in [`Handlers.get_anchor`][mkdocstrings.handlers.base.Handlers.get_anchor].
+    This configuration is used in [`Handlers.get_anchors`][mkdocstrings.handlers.base.Handlers.get_anchors].
 
     When trying to fix (optional) cross-references, the autorefs plugin will try to collect
     an object with every configured handler until one succeeds. It will then try to get

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -183,7 +183,7 @@ class MkdocstringsPlugin(BasePlugin):
             config["plugins"]["autorefs"] = autorefs
             log.debug(f"Added a subdued autorefs instance {autorefs!r}")
         # Add collector-based fallback in either case.
-        autorefs.get_fallback_anchor = self.handlers.get_anchor
+        autorefs.get_fallback_anchor = self.handlers.get_anchors
 
         mkdocstrings_extension = MkdocstringsExtension(extension_config, self.handlers, autorefs)
         config["markdown_extensions"].append(mkdocstrings_extension)


### PR DESCRIPTION
Since an object can have aliases (different identifiers
leading to it), and since users sometimes want to
render an object using one of its aliases instead of its
canonical identifier, we make sure to register every
identifier associated to an object so that autorefs
can find it when fixing cross-references.

Issue mkdocstrings/autorefs#11
Needs PR https://github.com/mkdocstrings/autorefs/pull/12