### PR TITLE
Fixed bad error catch

### DIFF
--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -252,19 +252,23 @@ class PythonCollector(BaseCollector):
             raise CollectionError(error) from exception
 
         error = result.get("error")
-        if error:
+        if error is not None:
             if "traceback" in result:
                 error += f"\n{result['traceback']}"
             raise CollectionError(error)
 
-        for loading_error in result["loading_errors"]:
-            log.warning(loading_error)
+        if "loading_errors" in result:
+            for loading_error in result["loading_errors"]:
+                log.warning(loading_error)
 
-        for errors in result["parsing_errors"].values():
-            for parsing_error in errors:
-                log.warning(parsing_error)
+        if "parsing_errors" in result:
+            for errors in result["parsing_errors"].values():
+                for parsing_error in errors:
+                    log.warning(parsing_error)
 
         # We always collect only one object at a time
+        if "objects" not in result:
+            raise CollectionError(f"No objects returned in {result} for python object: {identifier}")
         result = result["objects"][0]
 
         log.debug("Rebuilding categories and children lists")


### PR DESCRIPTION
See text below for detailed explanation.

```python
        error = result.get("error")  # Recall that .get returns None if there is no error
        if error is not None:  # In my particular error case the error was an empty string, which failed the old if since an empty string ~= false.
            if "traceback" in result:
                error += f"\n{result['traceback']}"
            raise CollectionError(error)

        if "loading_errors" in result:  # Without this check, the for loop results in a KeyError
            for loading_error in result["loading_errors"]:
                log.warning(loading_error)

        if "parsing_errors" in result:  # Without this check, the for loop results in a KeyError
            for errors in result["parsing_errors"].values():
                for parsing_error in errors:
                    log.warning(parsing_error)

        # We always collect only one object at a time
        if "objects" not in result:  # This may be unnecessary, but since the error wasn't caught above, this also became a KeyError.
            raise CollectionError(f"No objects returned in {result} for python object: {identifier}")
        result = result["objects"][0]

```