### PR TITLE
build: Update extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-python-legacy = ["mkdocstrings-python-legacy>=0.2"]
-python = ["mkdocstrings-python>=0.5.1"]
+crystal = ["mkdocstrings-crystal>=0.3.4"]
+python-legacy = ["mkdocstrings-python-legacy>=0.2.1"]
+python = ["mkdocstrings-python>=0.5.2"]
 
 [project.urls]
 Homepage = "https://mkdocstrings.github.io"


### PR DESCRIPTION
I just pushed new versions of both Python handlers to make sure they depend on `mkdocstrings>=0.18`, and so updated the extras here.

I've also added the `crystal` extra.