### PR TITLE
refactor: Prefix logs with the package name only

### DIFF
--- a/src/mkdocstrings/loggers.py
+++ b/src/mkdocstrings/loggers.py
@@ -122,7 +122,7 @@ def get_logger(name: str) -> LoggerAdapter:
     """
     logger = logging.getLogger(f"mkdocs.plugins.{name}")
     logger.addFilter(warning_filter)
-    return LoggerAdapter(name, logger)
+    return LoggerAdapter(name.split(".", 1)[0], logger)
 
 
 def get_template_logger() -> TemplateLogger:


### PR DESCRIPTION
Instead of prefixing logs with `mkdocstrings.extension: ` or `mkdocstrings.plugin: ` we prefix them with just `mkdocstrings: `.
I don't think it's useful to log the full module path (easy to know where the log comes from).
I'm trying to standardize a bit more logging from plugins :slightly_smiling_face: 