### PR TITLE
docs: Update note about supported docstring options

### DIFF
--- a/docs/handlers/overview.md
+++ b/docs/handlers/overview.md
@@ -80,8 +80,8 @@ dependencies = [
   except for the `restructured-text` style which is renamed `sphinx`.
   Numpy-style is now built-in, so you can stop depending on `pytkdocs[numpy-style]`
   or `docstring_parser`.
-- `docstring_options` is implemented, and used as before, however none
-  of the provided parsers accept any option yet.
+- `docstring_options` is implemented, and used as before.
+  Refer to the [`griffe` documentation](https://mkdocstrings.github.io/griffe/docstrings/#parsing-options) for the updated list of supported docstring options.
 - `new_path_syntax` is irrelevant now. If you were setting it to True,
   remove the option and replace every colon (`:`) in your autodoc identifiers
   by dots (`.`).


### PR DESCRIPTION
Just a small update to the documentation, pointing out that docstring options are available now under the experimental python handler. :)