### PR TITLE
Prevent Nonetype error in call to Markdown.convert

### DIFF
--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -215,16 +215,19 @@ class BaseRenderer(ABC):
         treeprocessors[HeadingShiftingTreeprocessor.name].shift_by = heading_level
         treeprocessors[IdPrependingTreeprocessor.name].id_prefix = html_id and html_id + "--"
         treeprocessors[ParagraphStrippingTreeprocessor.name].strip = strip_paragraph
-        try:
-            if text:
-                return Markup(self._md.convert(text))
-            else:
-                return Markup()
-        finally:
-            treeprocessors[HeadingShiftingTreeprocessor.name].shift_by = 0
-            treeprocessors[IdPrependingTreeprocessor.name].id_prefix = ""
-            treeprocessors[ParagraphStrippingTreeprocessor.name].strip = False
-            self._md.reset()
+        
+        html_str = Markup()
+        if text:
+            html_str = Markup(self._md.convert(text))
+        else:
+            log.warning(f"Mising expected text in {html_id}")
+           
+        treeprocessors[HeadingShiftingTreeprocessor.name].shift_by = 0
+        treeprocessors[IdPrependingTreeprocessor.name].id_prefix = ""
+        treeprocessors[ParagraphStrippingTreeprocessor.name].strip = False
+        self._md.reset()
+        
+        return html_str
 
     def do_heading(
         self,

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -220,7 +220,7 @@ class BaseRenderer(ABC):
         if text:
             html_str = Markup(self._md.convert(text))
         else:
-            log.warning(f"Mising expected text in {html_id}")
+            log.warning(f"Mising something in {html_id}")
            
         treeprocessors[HeadingShiftingTreeprocessor.name].shift_by = 0
         treeprocessors[IdPrependingTreeprocessor.name].id_prefix = ""

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -28,10 +28,11 @@ from mkdocstrings.handlers.rendering import (
     ParagraphStrippingTreeprocessor,
 )
 from mkdocstrings.inventory import Inventory
+from mkdocstrings.loggers import get_logger
 from mkdocstrings.loggers import get_template_logger
 
 CollectorItem = Any
-
+log = get_logger(__name__)
 
 class CollectionError(Exception):
     """An exception raised when some collection of data failed."""

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -216,7 +216,10 @@ class BaseRenderer(ABC):
         treeprocessors[IdPrependingTreeprocessor.name].id_prefix = html_id and html_id + "--"
         treeprocessors[ParagraphStrippingTreeprocessor.name].strip = strip_paragraph
         try:
-            return Markup(self._md.convert(text))
+            if text:
+                return Markup(self._md.convert(text))
+            else:
+                return Markup()
         finally:
             treeprocessors[HeadingShiftingTreeprocessor.name].shift_by = 0
             treeprocessors[IdPrependingTreeprocessor.name].id_prefix = ""


### PR DESCRIPTION
When docstring style is set to numpy, if you are missing part of the expected docstring you'll get a Nonetype error when it is passed to the Markdown module method. I opened a [PR in Markdown](https://github.com/Python-Markdown/markdown/pull/1223) to add a None check to prevent the error but [they explained that the check should be in the caller](https://github.com/Python-Markdown/markdown/pull/1223#issuecomment-1050912432) so I'm opening this PR.

Here is the error caused by the code as is in 0.18.1:

```
  File "/home/me/repo/venv/lib/python3.8/site-packages/mkdocstrings/handlers/base.py", line 219, in do_convert_markdown
    return Markup(self._md.convert(text))
  File "/home/me/repo/venv/lib/python3.8/site-packages/markdown/core.py", line 248, in convert
    if not source.strip():
AttributeError: 'NoneType' object has no attribute 'strip'
```

I edited my local copy of the file to test my changes and it worked. Rather than crashing, it kept going. If it's of interest, here are the warnings it gave. I expect one of these caused the crash:

```
WARNING  -  mkdocstrings: somemodule.someclass.somefunca: No type annotation for parameter 'model'
WARNING  -  mkdocstrings: somemodule.someclass.somefuncb: Empty return description
WARNING  -  mkdocstrings: somemodule.someclass.somefuncc: Empty return description
WARNING  -  mkdocstrings: somemodule.someclass.somefuncd: Empty return description
```

For final added context, I got this crash when running `python -m mkdocs build`.