### PR TITLE
refactor: Deprecate BaseCollector and BaseRenderer

### DIFF
--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -122,7 +122,7 @@ class AutoDocProcessor(BlockProcessor):
             # The final HTML is inserted as opaque to subsequent processing, and only revealed at the end.
             el.text = self.md.htmlStash.store(html)
             # So we need to duplicate the headings directly (and delete later), just so 'toc' can pick them up.
-            headings = handler.renderer.get_headings()
+            headings = handler.get_headings()
             el.extend(headings)
 
             page = self._autorefs.current_page
@@ -179,7 +179,7 @@ class AutoDocProcessor(BlockProcessor):
 
         log.debug("Collecting data")
         try:
-            data: CollectorItem = handler.collector.collect(identifier, selection)
+            data: CollectorItem = handler.collect(identifier, selection)
         except CollectionError as exception:
             log.error(str(exception))
             if PluginError is SystemExit:  # When MkDocs 1.2 is sufficiently common, this can be dropped.
@@ -188,12 +188,12 @@ class AutoDocProcessor(BlockProcessor):
 
         if not self._updated_env:
             log.debug("Updating renderer's env")
-            handler.renderer._update_env(self.md, self._config)  # noqa: WPS437 (protected member OK)
+            handler._update_env(self.md, self._config)  # noqa: WPS437 (protected member OK)
             self._updated_env = True
 
         log.debug("Rendering templates")
         try:
-            rendered = handler.renderer.render(data, rendering)
+            rendered = handler.render(data, rendering)
         except TemplateNotFound as exc:
             theme_name = self._config["theme_name"]
             log.error(

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -224,7 +224,7 @@ class MkdocstringsPlugin(BasePlugin):
         - Gather results from background inventory download tasks.
         """
         if self._handlers:
-            css_content = "\n".join(handler.renderer.extra_css for handler in self.handlers.seen_handlers)
+            css_content = "\n".join(handler.extra_css for handler in self.handlers.seen_handlers)
             write_file(css_content.encode("utf-8"), os.path.join(config["site_dir"], self.css_filename))
 
             if self.inventory_enabled:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -127,9 +127,9 @@ def test_use_custom_handler(ext_markdown):
 
 def test_dont_register_every_identifier_as_anchor(plugin):
     """Assert that we don't preemptively register all identifiers of a rendered object."""
-    renderer = plugin._handlers.get_handler("python").renderer  # noqa: WPS437
+    handler = plugin._handlers.get_handler("python")  # noqa: WPS437
     ids = {"id1", "id2", "id3"}
-    renderer.get_anchors = lambda _: ids
+    handler.get_anchors = lambda _: ids
     plugin.md.convert("::: tests.fixtures.headings")
     autorefs = plugin.md.parser.blockprocessors["mkdocstrings"]._autorefs  # noqa: WPS219,WPS437
     for identifier in ids:


### PR DESCRIPTION
Commit message:

The BaseCollector and BaseRenderer are merged into
the BaseHandler (as mixins for now).
Developers are still able to create collectors
and renderers using these deprecated base classes,
and pass instances of them when creating their handler.

All the methods of the deprecated bases can now
be defined on the BaseHandler subclass itself.
Handlers can then be instantiated by passing
the handler's name, the theme and the optional
custom templates folder name/path.

Reasoning: often times, the renderer and the collector
need to communicate or share data. For example,
the Crystal renderer uses the collector to lookup names
when creating cross-references. The Python handlers
are able to filter members when collecting/returning data,
and need the same members list when rendering,
to order the elements based on that list.

This change is the first of two, where the second change
will deprecate the use of `selection` and `rendering` keys
in the YAML options or MkDocs configuration, in favor of
a single `options` key that both the collection and rendering
process will share.

---

This change was mentioned in https://github.com/mkdocstrings/mkdocstrings/issues/364.
An example of what this implies for existing handlers: https://github.com/mkdocstrings/python/pull/10
Of course, nothing prevents developers from continuing to split their handler logic in multiple parts/classes/modules:

```python
def collect(self, identifier, config):
    return self._other_class.collect(identifier, config)
```