### PR TITLE
refactor: Deprecate 'selection' and 'rendering' YAML keys

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,11 +91,10 @@ plugins:
         - https://docs.python.org/3/objects.inv
         - https://docs.python-requests.org/en/master/objects.inv  # demonstration purpose in the docs
         - https://mkdocstrings.github.io/autorefs/objects.inv
-        selection:
+        options:
           docstring_style: google
           docstring_options:
             ignore_init_summary: yes
-        rendering:
           merge_init_into_class: yes
           show_submodules: no
     watch:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -139,8 +139,8 @@ def test_dont_register_every_identifier_as_anchor(plugin):
 
 def test_use_deprecated_yaml_keys(ext_markdown):
     """Check that using the deprecated 'selection' and 'rendering' YAML keys emits a deprecation warning."""
-    with pytest.warns(DeprecationWarning):
-        ext_markdown.convert("::: tests.fixtures.headings\n    rendering:\n      heading_level: 2")
+    with pytest.warns(DeprecationWarning, match="single 'options' YAML key"):
+        assert "h1" not in ext_markdown.convert("::: tests.fixtures.headings\n    rendering:\n      heading_level: 2")
 
 
 def test_use_new_options_yaml_key(ext_markdown):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -135,3 +135,15 @@ def test_dont_register_every_identifier_as_anchor(plugin):
     for identifier in ids:
         assert identifier not in autorefs._url_map  # noqa: WPS437
         assert identifier not in autorefs._abs_url_map  # noqa: WPS437
+
+
+def test_use_deprecated_yaml_keys(ext_markdown):
+    """Check that using the deprecated 'selection' and 'rendering' YAML keys emits a deprecation warning."""
+    with pytest.warns(DeprecationWarning):
+        ext_markdown.convert("::: tests.fixtures.headings\n    rendering:\n      heading_level: 2")
+
+
+def test_use_new_options_yaml_key(ext_markdown):
+    """Check that using the new 'options' YAML key works as expected."""
+    assert "h1" in ext_markdown.convert("::: tests.fixtures.headings\n    options:\n      heading_level: 1")
+    assert "h1" not in ext_markdown.convert("::: tests.fixtures.headings\n    options:\n      heading_level: 2")


### PR DESCRIPTION
Commit message:

As seen in commit eb822cb, the separation of
the selection/collection and rendering configuration
is problematic. This commit further reduces this
separation by merging the two current YAML keys
'selection' and 'rendering' into a single
'options' key. It means both the 'collect' and
'render' methods have access to every option.

The old keys can still be used, but are deprecated,
and therefore a deprecation warning is emitted
if these keys are found in either global or local
configurations.

---

This was mentioned in #364.
Example diffs:

```diff
 # mkdocs.yml
 plugins:
 - mkdocstrings:
     handlers:
       python:
-        selection:
+        options:
           docstring_style: google
           docstring_options:
             ignore_init_summary: yes
-        rendering:
           merge_init_into_class: yes
           show_submodules: no
```

```diff
 # My Class

 ::: my_package.MyClass
-    rendering:
+    options:
       show_root_toc_entry: no
```