### PR TITLE
feat: Pass config file path to handlers

### DIFF
--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -571,8 +571,9 @@ class Handlers:
                         )
                     )
             self._handlers[name] = module.get_handler(
-                self._config["theme_name"],
-                self._config["mkdocstrings"]["custom_templates"],
+                theme=self._config["theme_name"],
+                custom_templates=self._config["mkdocstrings"]["custom_templates"],
+                config_file_path=self._config["config_file_path"],
                 **handler_config,
             )
         return self._handlers[name]

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -166,6 +166,7 @@ class MkdocstringsPlugin(BasePlugin):
 
         extension_config = {
             "site_name": config["site_name"],
+            "config_file_path": config["config_file_path"],
             "theme_name": theme_name,
             "mdx": config["markdown_extensions"],
             "mdx_configs": config["mdx_configs"],


### PR DESCRIPTION
This is to allow handlers to build potential paths
(like Python search paths) relative to the MkDocs
configuration file path instead of the current
working directory. Without it, the build becomes
dependent on the CWD, breaking the --config-file
option.

Issue #311