### PR TITLE
Fix edit link for autogenerated docs

### DIFF
--- a/docs/gen_ref_nav.py
+++ b/docs/gen_ref_nav.py
@@ -24,7 +24,7 @@ for path in sorted(Path("src").glob("**/*.py")):
         ident = ".".join(parts)
         print("::: " + ident, file=fd)
 
-    mkdocs_gen_files.set_edit_path(full_doc_path, path)
+    mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
 
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -21,11 +21,11 @@ which live in the `src` folder:
 📁 repo
 └─╴📁 src
     └─╴📁 project
-        ├─╴📄 lorem.py
-        ├─╴📄 ipsum.py
-        ├─╴📄 dolor.py
-        ├─╴📄 sit.py
-        └─╴📄 amet.py
+        ├─╴📄 lorem
+        ├─╴📄 ipsum
+        ├─╴📄 dolor
+        ├─╴📄 sit
+        └─╴📄 amet
 ```
 
 Without an automatic process, you will have to manually
@@ -108,11 +108,7 @@ for path in sorted(Path("src").rglob("*.py")):  # (1)
 9. We can even set the `edit_uri` on the pages.
 
 > NOTE:
-> It is important to look out for correct edit page behaviour when using generated pages,
-> as `full_path` will be relative to the location of your `mkdocs.yml` path. You can fix
-> incorrect linking by traversing tree and adding it to the path before passing
-> it to `set_edit_path`.
->
+> It is important to look out for correct edit page behaviour when using generated pages.
 > For example, if we have `edit_uri` set to `blob/master/docs/` and the following
 > file structure:
 >

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -21,11 +21,11 @@ which live in the `src` folder:
 📁 repo
 └─╴📁 src
     └─╴📁 project
-        ├─╴📄 lorem
-        ├─╴📄 ipsum
-        ├─╴📄 dolor
-        ├─╴📄 sit
-        └─╴📄 amet
+        ├─╴📄 lorem.py
+        ├─╴📄 ipsum.py
+        ├─╴📄 dolor.py
+        ├─╴📄 sit.py
+        └─╴📄 amet.py
 ```
 
 Without an automatic process, you will have to manually
@@ -108,25 +108,29 @@ for path in sorted(Path("src").rglob("*.py")):  # (1)
 9. We can even set the `edit_uri` on the pages.
 
 > NOTE:
-> If your `edit_uri` is the default value or you have overwritten, you might
-> have to traverse the tree until you find the correct file from your `edit_uri`.
+> It is important to look out for correct edit page behaviour when using generated pages,
+> as `full_path` will be relative to the location of your `mkdocs.yml` path. You can fix
+> incorrect linking by traversing tree and adding it to the path before passing
+> it to `set_edit_path`.
 >
 > For example, if we have `edit_uri` set to `blob/master/docs/` and the following
 > file structure:
 >
 > ```
 > 📁 repo
+> ├─ 📄 mkdocs.yml
+> │
 > ├─ 📁 docs
 > │   ├─╴index.md
 > │   └─╴📄 gen_ref_pages.py
 > │
 > └─╴📁 src
 >    └─╴📁 project
->        ├─╴📄 lorem
->        ├─╴📄 ipsum
->        ├─╴📄 dolor
->        ├─╴📄 sit
->        └─╴📄 amet
+>        ├─╴📄 lorem.py
+>        ├─╴📄 ipsum.py
+>        ├─╴📄 dolor.py
+>        ├─╴📄 sit.py
+>        └─╴📄 amet.py
 > ```
 >
 > Then we will have to change our `set_edit_path` call to:
@@ -134,9 +138,12 @@ for path in sorted(Path("src").rglob("*.py")):  # (1)
 > ```python
 > mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path) # (1)
 > ```
->
 > 1. Path can be used to traverse the structure in any way you may need, but
 >    remember to use relative paths!
+>
+> so that it correctly sets the edit path of (for example) `lorem.py` to
+> `<repo_url>/blob/master/src/project/lorem.py` instead of
+> `<repo_url>/blob/master/docs/src/project/lorem.py`.
 
 With this script, a `reference` folder is automatically created
 each time we build our docs. This folder contains a Markdown page

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -107,6 +107,37 @@ for path in sorted(Path("src").rglob("*.py")):  # (1)
 8. Actually write to the magic file.
 9. We can even set the `edit_uri` on the pages.
 
+> NOTE:
+> If your `edit_uri` is the default value or you have overwritten, you might
+> have to traverse the tree until you find the correct file from your `edit_uri`.
+>
+> For example, if we have `edit_uri` set to `blob/master/docs/` and the following
+> file structure:
+>
+> ```
+> 📁 repo
+> ├─ 📁 docs
+> │   ├─╴index.md
+> │   └─╴📄 gen_ref_pages.py
+> │
+> └─╴📁 src
+>    └─╴📁 project
+>        ├─╴📄 lorem
+>        ├─╴📄 ipsum
+>        ├─╴📄 dolor
+>        ├─╴📄 sit
+>        └─╴📄 amet
+> ```
+>
+> Then we will have to change our `set_edit_path` call to:
+>
+> ```python
+> mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path) # (1)
+> ```
+>
+> 1. Path can be used to traverse the structure in any way you may need, but
+>    remember to use relative paths!
+
 With this script, a `reference` folder is automatically created
 each time we build our docs. This folder contains a Markdown page
 for each of our source modules, and each of these pages

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -117,7 +117,7 @@ for path in sorted(Path("src").rglob("*.py")):  # (1)
 > ├─ 📄 mkdocs.yml
 > │
 > ├─ 📁 docs
-> │   ├─╴index.md
+> │   ├─╴📄 index.md
 > │   └─╴📄 gen_ref_pages.py
 > │
 > └─╴📁 src

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: "mkdocstrings"
 site_description: "Automatic documentation from sources, for MkDocs."
 site_url: "https://mkdocstrings.github.io/"
-repo_url: "https://github.com/mkdocstrings/mkdocstrings/"
+repo_url: "https://github.com/mkdocstrings/mkdocstrings"
 edit_uri: "blob/master/docs/"
 repo_name: "mkdocstrings/mkdocstrings"
 site_dir: "site"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: "mkdocstrings"
 site_description: "Automatic documentation from sources, for MkDocs."
 site_url: "https://mkdocstrings.github.io/"
-repo_url: "https://github.com/mkdocstrings/mkdocstrings"
+repo_url: "https://github.com/mkdocstrings/mkdocstrings/"
 edit_uri: "blob/master/docs/"
 repo_name: "mkdocstrings/mkdocstrings"
 site_dir: "site"


### PR DESCRIPTION
Been going crazy about this for the last couple of hours and unable to figure out for my personal docs and saw that this behaviour was also reproducible in the repo. Eventually found it and it is caused by the use of [urllib.parse.urljoin](https://github.com/oprypin/mkdocs-gen-files/blob/master/mkdocs_gen_files/plugin.py#L49-L51) in the gen_files plugin, which misinterprets the links if they are not ended in `/` (@oprypin would you rather this gets fixed there instead?)

Additionally, I noticed that the `edit_uri` makes the edit links for the now correct links have `docs/` as a base, which makes it link incorrectly, so I added a bit of a hacky fix to avoid that

An example of the now broken page links can be seen [here](https://mkdocstrings.github.io/reference/extension/), where clicking on edit page leads to a 404.

```diff
- https://github.com/mkdocstrings/blob/master/docs/src/mkdocstrings/extension.py
+ https://github.com/mkdocstrings/mkdocstrings/blob/master/docs/src/mkdocstrings/extension.py
```

EDIT: Would also like to add that both these issues can be seen across all other repositories for extensions for mkdocstrings