### PR TITLE
feat: Add syntax to nest autodocs into other autodocs

### DIFF
--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1,0 +1,77 @@
+"""Tests for the syntax in the extension module."""
+
+import re
+from textwrap import dedent
+
+from markdown import Markdown
+from markupsafe import Markup
+from mkdocs_autorefs.plugin import AutorefsPlugin
+
+from mkdocstrings.extension import MkdocstringsExtension
+from mkdocstrings.handlers.base import BaseHandler
+from mkdocstrings.plugin import Handlers
+
+
+class FakeHandler(BaseHandler):
+    def __init__(self, with_heading=False, with_options=False):
+        self.with_heading = with_heading
+        self.with_options = with_options
+        super().__init__(handler="fake", theme="material")
+
+    def collect(self, identifier, config):
+        return identifier
+
+    def render(self, data, config):
+        heading_level = config.get("heading_level", 2)
+        html_id = data
+        doc = self.do_convert_markdown(f"Documentation for {data}", heading_level, html_id)
+        if self.with_heading:
+            doc = self.do_heading(data, heading_level, id=html_id) + doc
+        if self.with_options:
+            doc += " " + ",".join(f"{k}:{v}" for k, v in config.items())
+        return Markup('<div class="doc-object">{}</div>').format(doc)
+
+    def get_templates_dir(self, handler):
+        return super().get_templates_dir("python")
+
+
+def fake_ext_markdown(handler, config={}, markdown_extensions={}):
+    extension_config = {
+        "site_name": "foo",
+        "mdx": ["toc", *markdown_extensions],
+        "mdx_configs": markdown_extensions,
+        "mkdocstrings": {"default_handler": "fake"},
+        **config,
+    }
+    handlers = Handlers(extension_config)
+    handlers._handlers["fake"] = handler
+    autorefs = AutorefsPlugin()
+    extension = MkdocstringsExtension(extension_config, handlers, autorefs)
+    return Markdown(
+        extensions=["toc", extension, *markdown_extensions],
+        extension_configs=markdown_extensions,
+    )
+
+
+def test_options_and_text_around():
+    source = dedent(
+        """
+            hi
+            ::: foo.Bar
+                options:
+                    hi: 1
+             *after*
+            """
+    )
+    md = fake_ext_markdown(FakeHandler(with_options=True))
+    expected = dedent(
+        """
+        <p>hi</p>
+        <div class="doc-object">
+            <p>Documentation for foo.Bar</p> hi:1
+        </div>
+        <p><em>after</em></p>
+        """
+    ).strip()
+
+    assert md.convert(source).replace("\n", "") == re.sub("\n *", "", expected)


### PR DESCRIPTION
The syntax:
```markdown
::: foo --------

This text will be treated as an appendix to whatever content the docstring of `foo` produced

Identifiers can be nested too:

::: foo.Bar

Still going

--------

Now we are outside of the fence
```

The beginning fence exactly shares syntax with the syntax for `<hr>` and then the ending fence has to exactly match it.


https://user-images.githubusercontent.com/371383/185492525-987cbe8e-5088-4dab-b46c-9a7d0402f81b.mp4

https://user-images.githubusercontent.com/371383/185492513-e3e4517e-316b-4600-b058-a2bc8a08e417.mp4

---

This will be really useful for things like https://github.com/mkdocs/mkdocs/pull/2934. I've had a need for this feature for a long time for my other projects too. Only now came up with a decent syntax idea for it.

Please review commit-by-commit.

I am giving up on the "quality" lint complaints for now, they are totally unreasonable.