### PR TITLE
docs: Clarify `custom_templates` folder location in options documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,7 +108,8 @@ The above is equivalent to:
 
 - `default_handler`: the handler that is used by default when no handler is specified.
 - `custom_templates`: the path to a directory containing custom templates.
-  The path is relative to the docs directory.
+  The path is relative to the location of the docs directory.
+  If your templates folder is insde your docs directory, you do: `docs/...`.
   See [Theming](theming.md).
 - `handlers`: the handlers global configuration.
 - `enable_inventory`: whether to enable inventory file generation.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,8 +108,7 @@ The above is equivalent to:
 
 - `default_handler`: the handler that is used by default when no handler is specified.
 - `custom_templates`: the path to a directory containing custom templates.
-  The path is relative to the location of the docs directory.
-  If your templates folder is insde your docs directory, you do: `docs/...`.
+  The path is relative to the current working directory.
   See [Theming](theming.md).
 - `handlers`: the handlers global configuration.
 - `enable_inventory`: whether to enable inventory file generation.


### PR DESCRIPTION
A small PR to (in my opinion) improve the clarity of the `custom_templates` config option.  
The reason for this is that when I read the current line:

> the path to a directory containing custom templates. The path is relative to the docs directory

I assumed it meant it was relative to **within** the docs directory. 
Only after looking up other repositories with examples I noticed that you have to include `docs` in the path if your templates are in that folder.

This is not meant to be final, just an example. If this is not the place for the explanation, I don't mind moving it either. 