### PR TITLE
fix: Fix broken Sphinx inventory item regex

### DIFF
--- a/src/mkdocstrings/inventory.py
+++ b/src/mkdocstrings/inventory.py
@@ -46,7 +46,7 @@ class InventoryItem:
             uri = uri[: -len(self.name)] + "$"
         return f"{self.name} {self.domain}:{self.role} {self.priority} {uri} {dispname}"
 
-    sphinx_item_regex = re.compile(r"^(.+?)\s+(\S+):(\S+)\s+(-?\d+)\s+(\S+)\s+(.*)$")
+    sphinx_item_regex = re.compile(r"^(.+?)\s+(\S+):(\S+)\s+(-?\d+)\s+(\S+)\s*(.*)$")
 
     @classmethod
     def parse_sphinx(cls, line: str) -> "InventoryItem":


### PR DESCRIPTION
As mentioned in #496, some Sphinx inventories don't match the `sphinx_item_regex` defined in `InventoryItem`. Allowing any number of whitespace characters at the end instead of requiring at least one fixes this issue.

Fixes #496.