### PR TITLE
Adjust license entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "pdm.pep517.api"
 name = "mkdocstrings"
 description = "Automatic documentation from sources, for MkDocs."
 authors = [{name = "Timothée Mazzucotelli", email = "pawamoy@pm.me"}]
-license = "ISC"
+license = {text = "ISC"}
 readme = "README.md"
 requires-python = ">=3.7"
 keywords = ["mkdocs", "mkdocs-plugin", "docstrings", "autodoc", "documentation"]


### PR DESCRIPTION
Fixes

```bash
, line 85, in validate_pep621
      raise PEP621ValidationError(validator.errors)
  pdm.pep517.exceptions.PEP621ValidationError: {'license': ['none or more than one rule validate', {'oneof definition 0': ['must be of dict type'], 'oneof definition 1': ['must be of dict type']}]}
```