### PR TITLE
feat: add plugin `enabled` config option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,6 +113,9 @@ The above is equivalent to:
 - `handlers`: the handlers global configuration.
 - `enable_inventory`: whether to enable inventory file generation.
   See [Cross-references to other projects / inventories](#cross-references-to-other-projects-inventories)
+- `enabled` **(New in version 0.20)**: Whether to enable the plugin. Defaults to `true`.
+  Can be used to reduce build times when doing local development.
+  Especially useful when used with environment variables (see example below).
 - `watch` **(deprecated)**: a list of directories to watch while serving the documentation.
   See [Watch directories](#watch-directories). **Deprecated in favor of the now built-in
   [`watch` feature of MkDocs](https://www.mkdocs.org/user-guide/configuration/#watch).
@@ -121,6 +124,7 @@ The above is equivalent to:
     ```yaml title="mkdocs.yml"
     plugins:
     - mkdocstrings:
+        enabled: !ENV [ENABLE_MKDOCSTRINGS, true]
         custom_templates: templates
         default_handler: python
         handlers:
@@ -357,3 +361,4 @@ For example, it will not tell the Python handler to look for packages in these p
 (the paths are not added to the `PYTHONPATH` variable).
 If you want to tell Python where to look for packages and modules,
 see [Python Handler: Finding modules](https://mkdocstrings.github.io/python/usage/#finding-modules).
+

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -227,6 +227,7 @@ class MkdocstringsPlugin(BasePlugin):
             inventory_enabled = any(handler.enable_inventory for handler in self.handlers.seen_handlers)
         return inventory_enabled
 
+    @property
     def plugin_enabled(self) -> bool:
         """Tell if the plugin is enabled or not.
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,27 @@
+"""Tests for the mkdocstrings plugin."""
+
+
+from mkdocs.commands.build import build
+from mkdocs.config import load_config
+
+
+def test_disabling_plugin(tmp_path):
+    """Test disabling plugin."""
+    docs_dir = tmp_path / "docs"
+    site_dir = tmp_path / "site"
+    docs_dir.mkdir()
+    site_dir.mkdir()
+    docs_dir.joinpath("index.md").write_text("::: mkdocstrings")
+
+    mkdocs_config = load_config()
+    mkdocs_config["docs_dir"] = str(docs_dir)
+    mkdocs_config["site_dir"] = str(site_dir)
+    mkdocs_config["plugins"]["mkdocstrings"].config["enabled"] = False
+    mkdocs_config["plugins"].run_event("startup", command="build", dirty=False)
+    try:
+        build(mkdocs_config)
+    finally:
+        mkdocs_config["plugins"].run_event("shutdown")
+
+    # make sure the instruction was not processed
+    assert "::: mkdocstrings" in site_dir.joinpath("index.html").read_text()


### PR DESCRIPTION
Fixes #478.

For the docs entry I guessed that it will be released in version 0.20, this might have to be adjusted.

I considered adding a test but I couldn't see some obvious way to extend the test suite.