### PR TITLE
fix:  handle multiple handler's envs on same the doc

### DIFF
--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -73,7 +73,7 @@ class AutoDocProcessor(BlockProcessor):
         self._config = config
         self._handlers = handlers
         self._autorefs = autorefs
-        self._updated_env = False
+        self._updated_envs: set = set()
 
     def test(self, parent: Element, block: str) -> bool:
         """Match our autodoc instructions.
@@ -192,10 +192,10 @@ class AutoDocProcessor(BlockProcessor):
                 log.error(f"Error reading page '{self._autorefs.current_page}':")
             raise PluginError(f"Could not collect '{identifier}'") from exception
 
-        if not self._updated_env:
+        if handler_name not in self._updated_envs:  # We haven't seen this handler before on this document.
             log.debug("Updating renderer's env")
             handler._update_env(self.md, self._config)  # noqa: WPS437 (protected member OK)
-            self._updated_env = True
+            self._updated_envs.add(handler_name)
 
         log.debug("Rendering templates")
         try:

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -299,6 +299,7 @@ class BaseRenderer:
         self.env.filters["heading"] = self.do_heading
 
     def _update_env(self, md: Markdown, config: dict):
+        """Update our handler to point to our configured Markdown instance, grabbing some of the config from `md`."""
         extensions = config["mdx"] + [MkdocstringsInnerExtension(self._headings)]
 
         new_md = Markdown(extensions=extensions, extension_configs=config["mdx_configs"])


### PR DESCRIPTION
Didn't want to take the full performance hit of doing it every time, so it now tracks if this autodoc instance has seen this handler before and if not; updates the handler's env.

Additionally, add a doc string to `_update_env` just a breadcrumb.

References: #201
Fixes: #502

---
I had issues with the instructions in `contributing.md` and had to manually install pdm on both windows/osx.  I got format working but check_types and test failed in locations not associated with this change.