### PR TITLE
feat: expose the full config to handlers

### DIFF
--- a/docs/handlers/overview.md
+++ b/docs/handlers/overview.md
@@ -180,8 +180,8 @@ These arguments are all passed as keyword arguments, so you can ignore them
 by adding `**kwargs` or similar to your signature. You can also accept
 additional parameters: the handler's global-only options and/or the root
 config options. This gives flexibility and access to the mkdocs config, mkdocstring
-config and etc.. You should never modify the root config but can be used to get
-information about the mkdocs instance such as where the current `site_dir` lives.
+config etc.. You should never modify the root config but can use it to get
+information about the MkDocs instance such as where the current `site_dir` lives.
 See the [Mkdocs Configuration](https://www.mkdocs.org/user-guide/configuration/) for
 more info about what is accessible from it.
 

--- a/docs/handlers/overview.md
+++ b/docs/handlers/overview.md
@@ -134,7 +134,7 @@ Since version 0.14, you can create and use custom handlers
 thanks to namespace packages. For more information about namespace packages,
 [see their documentation](https://packaging.python.org/guides/packaging-namespace-packages/).
 
-TIP: **TL;DR - Project template for handlers.**  
+TIP: **TL;DR - Project template for handlers.**
 *mkdocstrings* provides a [Copier](https://github.com/copier-org/copier) template to kickstart
 new handlers: https://github.com/mkdocstrings/handler-template. To use it, install Copier
 (`pipx install copier`), then run `copier gh:mkdocstrings/handler-template my_handler`
@@ -178,8 +178,12 @@ This function takes the following parameters:
 
 These arguments are all passed as keyword arguments, so you can ignore them
 by adding `**kwargs` or similar to your signature. You can also accept
-additional parameters: the handler's global-only options will be passed
-to this function when instantiating your handler.
+additional parameters: the handler's global-only options and/or the root
+config options. This gives flexibility and access to the mkdocs config, mkdocstring
+config and etc.. You should never modify the root config but can be used to get
+information about the mkdocs instance such as where the current `site_dir` lives.
+See the [Mkdocs Configuration](https://www.mkdocs.org/user-guide/configuration/) for
+more info about what is accessible from it.
 
 Check out how the
 [Python handler](https://github.com/mkdocstrings/python/blob/master/src/mkdocstrings_handlers/python)

--- a/docs/handlers/overview.md
+++ b/docs/handlers/overview.md
@@ -134,7 +134,7 @@ Since version 0.14, you can create and use custom handlers
 thanks to namespace packages. For more information about namespace packages,
 [see their documentation](https://packaging.python.org/guides/packaging-namespace-packages/).
 
-TIP: **TL;DR - Project template for handlers.**
+TIP: **TL;DR - Project template for handlers.**  
 *mkdocstrings* provides a [Copier](https://github.com/copier-org/copier) template to kickstart
 new handlers: https://github.com/mkdocstrings/handler-template. To use it, install Copier
 (`pipx install copier`), then run `copier gh:mkdocstrings/handler-template my_handler`

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -513,7 +513,7 @@ class Handlers:
         """
         self._config = config
         self._handlers: Dict[str, BaseHandler] = {}
-        self.inventory: Inventory = Inventory(project=self._config["site_name"])
+        self.inventory: Inventory = Inventory(project=self._config["mkdocs"]["site_name"])
 
     def get_anchors(self, identifier: str) -> Sequence[str]:
         """Return the canonical HTML anchor for the identifier, if any of the seen handlers can collect it.
@@ -581,6 +581,7 @@ class Handlers:
         if name not in self._handlers:
             if handler_config is None:
                 handler_config = self.get_handler_config(name)
+            handler_config.update(self._config)
             try:
                 module = importlib.import_module(f"mkdocstrings_handlers.{name}")
             except ModuleNotFoundError:
@@ -595,7 +596,7 @@ class Handlers:
             self._handlers[name] = module.get_handler(
                 theme=self._config["theme_name"],
                 custom_templates=self._config["mkdocstrings"]["custom_templates"],
-                config_file_path=self._config["config_file_path"],
+                config_file_path=self._config["mkdocs"]["config_file_path"],
                 **handler_config,
             )
         return self._handlers[name]

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -173,12 +173,11 @@ class MkdocstringsPlugin(BasePlugin):
                 to_import.append((handler_name, import_item))
 
         extension_config = {
-            "site_name": config["site_name"],
-            "config_file_path": config["config_file_path"],
             "theme_name": theme_name,
             "mdx": config["markdown_extensions"],
             "mdx_configs": config["mdx_configs"],
             "mkdocstrings": self.config,
+            "mkdocs": config,
         }
         self._handlers = Handlers(extension_config)
 


### PR DESCRIPTION
Instead of just passing only the handler_config on initialization pass the full dictionary of `extension_config` directly to the handler.  Refactors items that were pulled from the full configuration to point directly to that object.

References: #501