### PR TITLE
docs: complete example for quick usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ conda install -c conda-forge mkdocstrings
 
 ## Quick usage
 
+In `mkdocs.yml`:
+
 ```yaml
-# mkdocs.yml
+site_name: "my_library"
+
 theme:
   name: "material"
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ conda install -c conda-forge mkdocstrings
 In `mkdocs.yml`:
 
 ```yaml
-site_name: "my_library"
+site_name: "My Library"
 
 theme:
   name: "material"

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -250,7 +250,7 @@ will expand or collapse when you click on them,
 revealing `__init__` modules under them
 (or equivalent modules in other languages, if relevant).
 Since we are documenting a public API, and given users
-never explicitely import `__init__` modules, it would be nice
+never explicitly import `__init__` modules, it would be nice
 if we could get rid of them and instead render their documentation
 inside the section itself.
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -18,7 +18,7 @@ so you can tweak the look and feel with extra CSS rules.
 ### Templates
 
 To use custom templates and override the theme ones,
-specify the relative path to your templates directory
+specify the relative path from `mkdocs.yml` to your templates directory
 with the `custom_templates` global configuration option:
 
 ```yaml title="mkdocs.yml"

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -18,7 +18,7 @@ so you can tweak the look and feel with extra CSS rules.
 ### Templates
 
 To use custom templates and override the theme ones,
-specify the relative path from `mkdocs.yml` to your templates directory
+specify the relative path to your templates directory
 with the `custom_templates` global configuration option:
 
 ```yaml title="mkdocs.yml"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -326,7 +326,7 @@ Reciprocally, *mkdocstrings* also allows to *generate* an inventory file in the 
 It will be enabled by default if the Python handler is used, and generated as `objects.inv` in the final site directory.
 Other projects will be able to cross-reference items from your project.
 
-To explicitely enable or disable the generation of the inventory file, use the global
+To explicitly enable or disable the generation of the inventory file, use the global
 `enable_inventory` option:
 
 ```yaml

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -106,18 +106,18 @@ The above is equivalent to:
 
 *mkdocstrings* accepts a few top-level configuration options in `mkdocs.yml`:
 
-- `default_handler`: the handler that is used by default when no handler is specified.
-- `custom_templates`: the path to a directory containing custom templates.
+- `default_handler`: The handler that is used by default when no handler is specified.
+- `custom_templates`: The path to a directory containing custom templates.
   The path is relative to the current working directory.
   See [Theming](theming.md).
-- `handlers`: the handlers global configuration.
-- `enable_inventory`: whether to enable inventory file generation.
+- `handlers`: The handlers' global configuration.
+- `enable_inventory`: Whether to enable inventory file generation.
   See [Cross-references to other projects / inventories](#cross-references-to-other-projects-inventories)
 - `enabled` **(New in version 0.20)**: Whether to enable the plugin. Defaults to `true`.
   Can be used to reduce build times when doing local development.
   Especially useful when used with environment variables (see example below).
-- `watch` **(deprecated)**: a list of directories to watch while serving the documentation.
-  See [Watch directories](#watch-directories). **Deprecated in favor of the now built-in
+- `watch` **(deprecated)**: A list of directories to watch while serving the documentation.
+  See [Watch directories](#watch-directories). Deprecated in favor of the now built-in
   [`watch` feature of MkDocs](https://www.mkdocs.org/user-guide/configuration/#watch).
 
 !!! example
@@ -361,4 +361,3 @@ For example, it will not tell the Python handler to look for packages in these p
 (the paths are not added to the `PYTHONPATH` variable).
 If you want to tell Python where to look for packages and modules,
 see [Python Handler: Finding modules](https://mkdocstrings.github.io/python/usage/#finding-modules).
-

--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -154,7 +154,7 @@ class AutoDocProcessor(BlockProcessor):
         Arguments:
             identifier: The identifier of the object to collect and render.
             yaml_block: The YAML configuration.
-            heading_level: Suggested level of the the heading to insert (0 to ignore).
+            heading_level: Suggested level of the heading to insert (0 to ignore).
 
         Raises:
             PluginError: When something wrong happened during collection.

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -329,7 +329,7 @@ class BaseCollector:
             identifier: An identifier for which to collect data. For example, in Python,
                 it would be 'mkdocstrings.handlers' to collect documentation about the handlers module.
                 It can be anything that you can feed to the tool of your choice.
-            config: The handler's configuraton options.
+            config: The handler's configuration options.
 
         Returns:
             Anything you want, as long as you can feed it to the renderer's `render` method.
@@ -373,7 +373,7 @@ class BaseHandler(BaseCollector, BaseRenderer):
             **kwargs: Same thing, but with keyword arguments.
 
         Raises:
-            ValueError: When the givin parameters are invalid.
+            ValueError: When the given parameters are invalid.
         """
         # The method accepts *args and **kwargs temporarily,
         # to support the transition period where the BaseCollector

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -124,7 +124,7 @@ class BaseRenderer:
 
         Arguments:
             data: The collected data to render.
-            config: The handler's configuraton options.
+            config: The handler's configuration options.
 
         Returns:
             The rendered template as HTML.
@@ -577,7 +577,7 @@ class Handlers:
 
         Returns:
             An instance of a subclass of [`BaseHandler`][mkdocstrings.handlers.base.BaseHandler],
-            as instantiated by the `get_handler` method of the handler's module.
+                as instantiated by the `get_handler` method of the handler's module.
         """
         if name not in self._handlers:
             if handler_config is None:


### PR DESCRIPTION
Just a minor change to the Quick Usage example in the README, so that it runs as-is. (`mkdocs` complains about no `site_name` defined otherwise).

---

EDIT 2023-01-26: and a few other typos / docs clarification.