### PR TITLE
Update language extras install examples with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pip install mkdocstrings
 You can install support for specific languages using extras, for example:
 
 ```bash
-pip install mkdocstrings[crystal,python]
+pip install 'mkdocstrings[crystal,python]'
 ```
 
 See the [available language handlers](https://mkdocstrings.github.io/handlers/overview/).


### PR DESCRIPTION
I'm just getting started. I use Python fairly frequently but am not a tooling expert and don't know a lot about package naming conventions. Here was my journey:
- First I copied `pip install mkdocstrings[crystal,python]` exactly and that didn't work.
- Then I figured maybe `[crystal,python]` was intended as some kind of disjunction notation so I tried `mkdocstringpython` and that didn't work.
- Then I followed the link to https://mkdocstrings.github.io/handlers/overview/ and didn't see anything about pip installation.
- Then I clicked on the experimental link and made my way to https://mkdocstrings.github.io/python/
- Then I saw `mkdocstrings-python` in the PEP 621 declaration and tried `pip install mkdocstrings-python`

That feels like a lot of unnecessary friction! I think the clearest is to have the two examples one after the other as I have proposed.