### PR TITLE
feat: Allow extensions to add templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "mkdocs>=1.2",
     "mkdocs-autorefs>=0.3.1",
     "pymdown-extensions>=6.3",
+    "importlib-metadata>=4.6; python_version < '3.10'",
     "typing-extensions>=4.1; python_version < '3.10'",
 ]
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import pytest
+from jinja2.exceptions import TemplateNotFound
 from markdown import Markdown
 
-from mkdocstrings.handlers.base import Highlighter
+from mkdocstrings.handlers.base import BaseRenderer, Highlighter
+
+if TYPE_CHECKING:
+    from mkdocstrings.plugin import MkdocstringsPlugin
 
 
 @pytest.mark.parametrize("extension_name", ["codehilite", "pymdownx.highlight"])
@@ -43,3 +51,53 @@ def test_highlighter_basic(extension_name: str | None, inline: bool) -> None:
     actual = hl.highlight("import foo", language="python", inline=inline)
     assert "import" in actual
     assert "import foo" not in actual  # Highlighting has split it up.
+
+
+@pytest.fixture(name="extended_templates")
+def fixture_extended_templates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:  # noqa: D103
+    monkeypatch.setattr(BaseRenderer, "get_extended_templates_dirs", lambda self, handler: [tmp_path])
+    return tmp_path
+
+
+def test_extended_templates(extended_templates: Path, plugin: MkdocstringsPlugin) -> None:
+    """Test the extended templates functionality.
+
+    Parameters:
+        extended_templates: Temporary folder.
+        plugin: Instance of our plugin.
+    """
+    handler = plugin._handlers.get_handler("python")  # type: ignore[union-attr]
+
+    # assert mocked method added temp path to loader
+    search_paths = handler.env.loader.searchpath  # type: ignore[union-attr]
+    assert any(str(extended_templates) in path for path in search_paths)
+
+    # assert "new" template is not found
+    for path in search_paths:
+        # TODO: use missing_ok=True once support for Python 3.7 is dropped
+        with suppress(FileNotFoundError):
+            Path(path).joinpath("new.html").unlink()
+    with pytest.raises(expected_exception=TemplateNotFound):
+        handler.env.get_template("new.html")
+
+    # check precedence: base theme, base fallback theme, extended theme, extended fallback theme
+    # start with last one and go back up
+    handler.env.cache = None
+
+    extended_fallback_theme = extended_templates.joinpath(handler.fallback_theme)
+    extended_fallback_theme.mkdir()
+    extended_fallback_theme.joinpath("new.html").write_text("extended fallback new")
+    assert handler.env.get_template("new.html").render() == "extended fallback new"
+
+    extended_theme = extended_templates.joinpath("mkdocs")
+    extended_theme.mkdir()
+    extended_theme.joinpath("new.html").write_text("extended new")
+    assert handler.env.get_template("new.html").render() == "extended new"
+
+    base_fallback_theme = Path(search_paths[1])
+    base_fallback_theme.joinpath("new.html").write_text("base fallback new")
+    assert handler.env.get_template("new.html").render() == "base fallback new"
+
+    base_theme = Path(search_paths[0])
+    base_theme.joinpath("new.html").write_text("base new")
+    assert handler.env.get_template("new.html").render() == "base new"


### PR DESCRIPTION
An extension here is simply a Python package that defines an entry-point for a specific handler.

For example, an extension can add templates to the Python handler thanks to this entry-point:

```toml
[project.entry-points."mkdocstrings.python.templates"]
extension-name = "extension_package:get_templates_path"
```

This entry-point assumes that the extension provides a `get_templates_path` function directly under the `extension_package` package. This function doesn't accept any argument and returns the path to a directory containing templates. The directory must contain one subfolder for each supported theme, for example:

```
templates/
    material/
    readthedocs/
    mkdocs/
```

mkdocstrings will add the folders corresponding to the user-selected theme, and to the handler's defined fallback theme, as usual.

The names of the extension templates must not overlap with the handler's original templates.

The extension is then responsible, in collaboration with its target handler, for mutating the collected data in order to instruct the handler to use one of the extension template when rendering particular objects.

For example, the Python handler will look for a `template` attribute on objects, and use it to render the object. This `template` attribute will be set by Griffe extensions (Griffe is the tool used by the Python handler to collect data).
See related PR: https://github.com/mkdocstrings/python/pull/70

----

### TODO

- [x] docs
- [x] tests