### PR TITLE
feat: allow ::: pattern in indented blocks

### DIFF
--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -59,7 +59,7 @@ class AutoDocProcessor(BlockProcessor):
     a matched block.
     """
 
-    regex = re.compile(r"^(?P<heading>#{1,6} *|)::: ?(?P<name>.+?) *$", flags=re.MULTILINE)
+    regex = re.compile(r"^ *(?P<heading>#{1,6} *|)::: ?(?P<name>.+?) *$", flags=re.MULTILINE)
 
     def __init__(
         self,


### PR DESCRIPTION
Hi,

This PR extends the autodoc syntax to allow inserting autodocs in indented blocks.
This allows, for instance, to write the following (collapsible autdoc):

```md
??? note "Reference"

    ::: my_project.my_file.my_class
        options:
          heading_level: 3
```

which was not possible before.

Let me know what you think !