### PR TITLE
Add note about newline handling

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,8 @@ markdown_extensions:
 - pymdownx.superfences
 ```
 
+Note: If a code-block has a newline, "\n", you must escape it with an additional "\\", eg ```msg = "This line has a newline char at the end \\n"```
+
 ## Footnotes are duplicated or overridden
 
 Before version 0.14, footnotes could be duplicated over a page.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,8 +21,8 @@ markdown_extensions:
 - pymdownx.superfences
 ```
 
-For code blocks in docstrings, make sure to escape newlines: `\n` -> `\\n`, or prefix
-the entire docstring with 'r' to make it a raw-docstring: <code>r"""</code>.
+For code blocks in docstrings, make sure to escape newlines (`\n` -> `\\n`),
+or prefix the entire docstring with 'r' to make it a raw-docstring: `r"""`.
 Indeed, docstrings are still strings and therefore subject to how Python parses strings.
 
 ## Footnotes are duplicated or overridden

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,7 +21,9 @@ markdown_extensions:
 - pymdownx.superfences
 ```
 
-Note: If a code-block has a newline, "\n", you must escape it with an additional "\\", eg ```msg = "This line has a newline char at the end \\n"```
+For code blocks in docstrings, make sure to escape newlines: `\n` -> `\\n`, or prefix
+the entire docstring with 'r' to make it a raw-docstring: <code>r"""</code>.
+Indeed, docstrings are still strings and therefore subject to how Python parses strings.
 
 ## Footnotes are duplicated or overridden
 


### PR DESCRIPTION
I added a note about new-line handling. Maybe its a bug that I should be reporting elsewhere?

```python
class ExampleClass:
    """This class is broken because of \n

    Example:
    ```python
    msg = "There should be a newline char at the end of this example\n"
    print(msg)
    ```
    """
    pass
```

produces this:

> ![image](https://github.com/mkdocstrings/mkdocstrings/assets/57631333/3ae8d7ca-5308-469d-a2b8-cc3e3bc0e517)

Escaping the "\n" with an additional "\" produces:

> ![image](https://github.com/mkdocstrings/mkdocstrings/assets/57631333/49f957a6-1c6c-490d-b4b2-a7f827d39044)

my mkdocs.yaml:
```mkdocs
markdown_extensions:
    - admonition
    - codehilite
    - pymdownx.superfences

plugins:
- search
- mkdocstrings:
    handlers:
      python:
        options:
          docstring_style: "google"
