### PR TITLE
Remove duplicated headings for docstrings nested in tabs/admonitions

### DIFF
--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -231,12 +231,12 @@ class AutoDocProcessor(BlockProcessor):
 
 class _PostProcessor(Treeprocessor):
     def run(self, root: Element) -> None:
-        self.remove_duplicated_headings_from_parent(root)
+        self._remove_duplicated_headings(root)
 
-    def remove_duplicated_headings_from_parent(self, parent: Element) -> bool:
+    def _remove_duplicated_headings(self, parent: Element) -> bool:
         carry_text = ""
         found = False
-        for el in reversed(parent):
+        for el in reversed(parent):  # Reversed mainly for the ability to mutate during iteration.
             if el.tag == "div" and el.get("class") == "mkdocstrings":
                 # Delete the duplicated headings along with their container, but keep the text (i.e. the actual HTML).
                 carry_text = (el.text or "") + carry_text
@@ -245,7 +245,7 @@ class _PostProcessor(Treeprocessor):
             elif carry_text:
                 el.tail = (el.tail or "") + carry_text
                 carry_text = ""
-            elif self.remove_duplicated_headings_from_parent(el):
+            elif self._remove_duplicated_headings(el):
                 found = True
                 break
         if carry_text:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -153,13 +153,11 @@ def test_use_options_yaml_key(ext_markdown: Markdown) -> None:
 
 
 @pytest.mark.parametrize("ext_markdown", [{"markdown_extensions": [{"pymdownx.tabbed": {"alternate_style": True}}]}], indirect=["ext_markdown"])
-def test_tab_headings(ext_markdown: Markdown) -> None:
-    """Assert footnotes don't get added to subsequent docstrings."""
+def test_removing_duplicated_headings(ext_markdown: Markdown) -> None:
+    """Assert duplicated headings are removed from the output."""
     output = ext_markdown.convert(
         dedent(
             """
-            Top.[^aaa]
-
             === "Tab A"
 
                 ::: tests.fixtures.headings

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -150,3 +150,23 @@ def test_use_options_yaml_key(ext_markdown: Markdown) -> None:
     """Check that using the 'options' YAML key works as expected."""
     assert "h1" in ext_markdown.convert("::: tests.fixtures.headings\n    options:\n      heading_level: 1")
     assert "h1" not in ext_markdown.convert("::: tests.fixtures.headings\n    options:\n      heading_level: 2")
+
+
+@pytest.mark.parametrize("ext_markdown", [{"markdown_extensions": [{"pymdownx.tabbed": {"alternate_style": True}}]}], indirect=["ext_markdown"])
+def test_tab_headings(ext_markdown: Markdown) -> None:
+    """Assert footnotes don't get added to subsequent docstrings."""
+    output = ext_markdown.convert(
+        dedent(
+            """
+            Top.[^aaa]
+
+            === "Tab A"
+
+                ::: tests.fixtures.headings
+
+            """,
+        ),
+    )
+    assert output.count("Foo") == 1
+    assert output.count("Bar") == 1
+    assert output.count("Baz") == 1


### PR DESCRIPTION
Hi,

As mentioned in #609, nesting a docstring in another block (e.g., tab or admonition) produces duplicated headings.
At the moment, the extension postprocessor only checks inside the immediate root children when removing duplicated heading.

Some markdown extensions move the produced docstring in a nested html node : we only need to search deeply when removing duplicatas.