### PR TITLE
fix: Properly fix duplicated headings for nested docstrings

### DIFF
--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -233,24 +233,21 @@ class _PostProcessor(Treeprocessor):
     def run(self, root: Element) -> None:
         self._remove_duplicated_headings(root)
 
-    def _remove_duplicated_headings(self, parent: Element) -> bool:
+    def _remove_duplicated_headings(self, parent: Element) -> None:
         carry_text = ""
-        found = False
         for el in reversed(parent):  # Reversed mainly for the ability to mutate during iteration.
             if el.tag == "div" and el.get("class") == "mkdocstrings":
                 # Delete the duplicated headings along with their container, but keep the text (i.e. the actual HTML).
                 carry_text = (el.text or "") + carry_text
                 parent.remove(el)
-                found = True
-            elif carry_text:
-                el.tail = (el.tail or "") + carry_text
-                carry_text = ""
-            elif self._remove_duplicated_headings(el):
-                found = True
-                break
+            else:
+                if carry_text:
+                    el.tail = (el.tail or "") + carry_text
+                    carry_text = ""
+                self._remove_duplicated_headings(el)
+
         if carry_text:
             parent.text = (parent.text or "") + carry_text
-        return found
 
 
 class MkdocstringsExtension(Extension):

--- a/tests/fixtures/headings_many.py
+++ b/tests/fixtures/headings_many.py
@@ -1,0 +1,10 @@
+def heading_1():
+    """## Heading one"""
+
+
+def heading_2():
+    """### Heading two"""
+
+
+def heading_3():
+    """#### Heading three"""

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -152,19 +152,23 @@ def test_use_options_yaml_key(ext_markdown: Markdown) -> None:
     assert "h1" not in ext_markdown.convert("::: tests.fixtures.headings\n    options:\n      heading_level: 2")
 
 
-@pytest.mark.parametrize("ext_markdown", [{"markdown_extensions": [{"pymdownx.tabbed": {"alternate_style": True}}]}], indirect=["ext_markdown"])
+@pytest.mark.parametrize("ext_markdown", [{"markdown_extensions": [{"admonition": {}}]}], indirect=["ext_markdown"])
 def test_removing_duplicated_headings(ext_markdown: Markdown) -> None:
     """Assert duplicated headings are removed from the output."""
     output = ext_markdown.convert(
         dedent(
             """
-            === "Tab A"
+            ::: tests.fixtures.headings_many.heading_1
 
-                ::: tests.fixtures.headings
+            !!! note
 
+                ::: tests.fixtures.headings_many.heading_2
+
+            ::: tests.fixtures.headings_many.heading_3
             """,
         ),
     )
-    assert output.count("Foo") == 1
-    assert output.count("Bar") == 1
-    assert output.count("Baz") == 1
+    assert output.count(">Heading one<") == 1
+    assert output.count(">Heading two<") == 1
+    assert output.count(">Heading three<") == 1
+    assert output.count('class="mkdocstrings') == 0


### PR DESCRIPTION
In the newly added test these were failing in the previous state:

* `assert output.count(">Heading one<") == 1` - [**comment**](https://github.com/mkdocstrings/mkdocstrings/pull/610/files/d0f06d4b80765ce2e6b8e27fb410439506cc318c#r1328531524)

* `assert output.count(">Heading two<") == 1` - [**comment**](https://github.com/mkdocstrings/mkdocstrings/pull/610/files/d0f06d4b80765ce2e6b8e27fb410439506cc318c#r1328530389)

And delete unused boolean