### PR TITLE
Circumvent error with mkdocs link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![gitpod](https://img.shields.io/badge/gitpod-workspace-blue.svg?style=flat)](https://gitpod.io/#https://github.com/mkdocstrings/mkdocstrings)
 [![gitter](https://badges.gitter.im/join%20chat.svg)](https://app.gitter.im/#/room/#mkdocstrings:gitter.im)
 
-Automatic documentation from sources, for [MkDocs](https://mkdocs.org/).
+Automatic documentation from sources, for [MkDocs](https://www.mkdocs.org/).
 Come have a chat or ask questions on our [Gitter channel](https://gitter.im/mkdocstrings/community).
 
 ---


### PR DESCRIPTION
Hi,

Currently navigating to https://mkdocs.org/ causes a certification error.

![mkdocs_error](https://github.com/mkdocstrings/mkdocstrings/assets/4184070/bf8a3b3b-9d61-441c-b647-3e87537305c3)


Changing the link to https://www.mkdocs.org/ circumvents this.