### PR TITLE
refactor: Backup anchors without hrefs, for compatibility with autorefs' Markdown anchors

### DIFF
--- a/src/mkdocstrings/handlers/rendering.py
+++ b/src/mkdocstrings/handlers/rendering.py
@@ -150,9 +150,9 @@ class IdPrependingTreeprocessor(Treeprocessor):
             self._prefix_ids(root)
 
     def _prefix_ids(self, root: Element) -> None:
-        index = -1
+        index = len(root)
         for el in reversed(root):  # Reversed mainly for the ability to mutate during iteration.
-            index += 1
+            index -= 1
 
             self._prefix_ids(el)
             href_attr = el.get("href")

--- a/src/mkdocstrings/handlers/rendering.py
+++ b/src/mkdocstrings/handlers/rendering.py
@@ -147,7 +147,7 @@ class IdPrependingTreeprocessor(Treeprocessor):
 
     @staticmethod
     def _iter(parent: Element) -> Iterator[tuple[Element, int, Element]]:
-        for index, element in enumerate(parent._children):
+        for index, element in enumerate(parent):
             yield parent, index, element
             yield from IdPrependingTreeprocessor._iter(element)
 

--- a/src/mkdocstrings/handlers/rendering.py
+++ b/src/mkdocstrings/handlers/rendering.py
@@ -151,7 +151,7 @@ class IdPrependingTreeprocessor(Treeprocessor):
 
     def _prefix_ids(self, root: Element) -> None:
         index = -1
-        for el in reversed(root):
+        for el in reversed(root):  # Reversed mainly for the ability to mutate during iteration.
             index += 1
 
             self._prefix_ids(el)
@@ -159,12 +159,18 @@ class IdPrependingTreeprocessor(Treeprocessor):
 
             if id_attr := el.get("id"):
                 if el.tag == "a" and not href_attr:
+                    # An anchor with id and no href is used by autorefs:
+                    # leave it untouched and insert a copy with updated id after it.
                     new_el = copy.deepcopy(el)
                     new_el.set("id", self.id_prefix + id_attr)
                     root.insert(index + 1, new_el)
                 else:
+                    # Anchors with id and href are not used by autorefs:
+                    # update in place.
                     el.set("id", self.id_prefix + id_attr)
 
+            # Always update hrefs, names and labels-for:
+            # there will always be a corresponding id.
             if href_attr and href_attr.startswith("#"):
                 el.set("href", "#" + self.id_prefix + href_attr[1:])
 

--- a/tests/fixtures/markdown_anchors.py
+++ b/tests/fixtures/markdown_anchors.py
@@ -4,7 +4,9 @@
 
 Paragraph.
 
-[](){#heading-anchor}
+[](){#heading-anchor-1}
+[](){#heading-anchor-2}
+[](){#heading-anchor-3}
 ## Heading
 
 [](#has-href1)

--- a/tests/fixtures/markdown_anchors.py
+++ b/tests/fixtures/markdown_anchors.py
@@ -1,0 +1,11 @@
+"""Module docstring.
+
+[](){#anchor}
+
+Paragraph.
+
+[](){#heading-anchor}
+## Heading
+
+Pararaph.
+"""

--- a/tests/fixtures/markdown_anchors.py
+++ b/tests/fixtures/markdown_anchors.py
@@ -7,5 +7,8 @@ Paragraph.
 [](){#heading-anchor}
 ## Heading
 
+[](#has-href1)
+[](#has-href2){#with-id}
+
 Pararaph.
 """

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -174,7 +174,7 @@ def test_removing_duplicated_headings(ext_markdown: Markdown) -> None:
     assert output.count('class="mkdocstrings') == 0
 
 
-def assert_contains_in_order(items: list[str], string: str):
+def _assert_contains_in_order(items: list[str], string: str) -> None:
     index = 0
     for item in items:
         assert item in string[index:]
@@ -187,7 +187,7 @@ def test_backup_of_anchors(ext_markdown: Markdown) -> None:
     output = ext_markdown.convert("::: tests.fixtures.markdown_anchors")
 
     # Anchors with id and no href have been backed up and updated.
-    assert_contains_in_order(
+    _assert_contains_in_order(
         [
             'id="anchor"',
             'id="tests.fixtures.markdown_anchors--anchor"',
@@ -202,7 +202,7 @@ def test_backup_of_anchors(ext_markdown: Markdown) -> None:
     )
 
     # Anchors with href and with or without id have been updated but not backed up.
-    assert_contains_in_order(
+    _assert_contains_in_order(
         [
             'id="tests.fixtures.markdown_anchors--with-id"',
         ],
@@ -210,7 +210,7 @@ def test_backup_of_anchors(ext_markdown: Markdown) -> None:
     )
     assert 'id="with-id"' not in output
 
-    assert_contains_in_order(
+    _assert_contains_in_order(
         [
             'href="#tests.fixtures.markdown_anchors--has-href1"',
             'href="#tests.fixtures.markdown_anchors--has-href2"',

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -172,3 +172,13 @@ def test_removing_duplicated_headings(ext_markdown: Markdown) -> None:
     assert output.count(">Heading two<") == 1
     assert output.count(">Heading three<") == 1
     assert output.count('class="mkdocstrings') == 0
+
+
+@pytest.mark.parametrize("ext_markdown", [{"markdown_extensions": [{"attr_list": {}}]}], indirect=["ext_markdown"])
+def test_backup_of_anchors(ext_markdown: Markdown) -> None:
+    """Anchors with empty `href` are backed up."""
+    output = ext_markdown.convert("::: tests.fixtures.markdown_anchors")
+    assert 'id="anchor"' in output
+    assert 'id="tests.fixtures.markdown_anchors--anchor"' in output
+    assert 'id="heading-anchor"' in output
+    assert 'id="tests.fixtures.markdown_anchors--heading-anchor"' in output

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -186,7 +186,7 @@ def test_backup_of_anchors(ext_markdown: Markdown) -> None:
     """Anchors with empty `href` are backed up."""
     output = ext_markdown.convert("::: tests.fixtures.markdown_anchors")
 
-    # Anchors with id and no href are been backed up and updated.
+    # Anchors with id and no href have been backed up and updated.
     assert_contains_in_order(
         [
             'id="anchor"',

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -174,22 +174,48 @@ def test_removing_duplicated_headings(ext_markdown: Markdown) -> None:
     assert output.count('class="mkdocstrings') == 0
 
 
+def assert_contains_in_order(items: list[str], string: str):
+    index = 0
+    for item in items:
+        assert item in string[index:]
+        index = string.index(item, index) + len(item)
+
+
 @pytest.mark.parametrize("ext_markdown", [{"markdown_extensions": [{"attr_list": {}}]}], indirect=["ext_markdown"])
 def test_backup_of_anchors(ext_markdown: Markdown) -> None:
     """Anchors with empty `href` are backed up."""
     output = ext_markdown.convert("::: tests.fixtures.markdown_anchors")
 
     # Anchors with id and no href are been backed up and updated.
-    assert 'id="anchor"' in output
-    assert 'id="tests.fixtures.markdown_anchors--anchor"' in output
-    assert 'id="heading-anchor"' in output
-    assert 'id="tests.fixtures.markdown_anchors--heading-anchor"' in output
+    assert_contains_in_order(
+        [
+            'id="anchor"',
+            'id="tests.fixtures.markdown_anchors--anchor"',
+            'id="heading-anchor-1"',
+            'id="tests.fixtures.markdown_anchors--heading-anchor-1"',
+            'id="heading-anchor-2"',
+            'id="tests.fixtures.markdown_anchors--heading-anchor-2"',
+            'id="heading-anchor-3"',
+            'id="tests.fixtures.markdown_anchors--heading-anchor-3"',
+        ],
+        output,
+    )
 
     # Anchors with href and with or without id have been updated but not backed up.
-    assert 'id="tests.fixtures.markdown_anchors--with-id"' in output
+    assert_contains_in_order(
+        [
+            'id="tests.fixtures.markdown_anchors--with-id"',
+        ],
+        output,
+    )
     assert 'id="with-id"' not in output
 
-    assert 'href="#tests.fixtures.markdown_anchors--has-href1"' in output
-    assert 'href="#tests.fixtures.markdown_anchors--has-href2"' in output
+    assert_contains_in_order(
+        [
+            'href="#tests.fixtures.markdown_anchors--has-href1"',
+            'href="#tests.fixtures.markdown_anchors--has-href2"',
+        ],
+        output,
+    )
     assert 'href="#has-href1"' not in output
     assert 'href="#has-href2"' not in output

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -178,7 +178,18 @@ def test_removing_duplicated_headings(ext_markdown: Markdown) -> None:
 def test_backup_of_anchors(ext_markdown: Markdown) -> None:
     """Anchors with empty `href` are backed up."""
     output = ext_markdown.convert("::: tests.fixtures.markdown_anchors")
+
+    # Anchors with id and no href are been backed up and updated.
     assert 'id="anchor"' in output
     assert 'id="tests.fixtures.markdown_anchors--anchor"' in output
     assert 'id="heading-anchor"' in output
     assert 'id="tests.fixtures.markdown_anchors--heading-anchor"' in output
+
+    # Anchors with href and with or without id have been updated but not backed up.
+    assert 'id="tests.fixtures.markdown_anchors--with-id"' in output
+    assert 'id="with-id"' not in output
+
+    assert 'href="#tests.fixtures.markdown_anchors--has-href1"' in output
+    assert 'href="#tests.fixtures.markdown_anchors--has-href2"' in output
+    assert 'href="#has-href1"' not in output
+    assert 'href="#has-href2"' not in output


### PR DESCRIPTION
This will be useful for the soon-to-come Markdown anchors feature of mkdocs-autorefs.

Related to mkdocs-autorefs#39: https://github.com/mkdocstrings/autorefs/pull/39