### PR TITLE
Clarify that extras are *necessary* not optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ Come have a chat or ask questions on our [Gitter channel](https://gitter.im/mkdo
 
 ## Installation
 
-With `pip`:
+Use `pip` to install mkdocstrings *without support for any languages*:
 
 ```bash
 pip install mkdocstrings
 ```
 
-You can install support for specific languages using extras, for example:
+You must install support for specific languages using extras. For example,
+the following installs mkdocstrings with support for Crystal and Python:
 
 ```bash
 pip install 'mkdocstrings[crystal,python]'

--- a/README.md
+++ b/README.md
@@ -78,25 +78,31 @@ Come have a chat or ask questions on our [Gitter channel](https://gitter.im/mkdo
 
 ## Installation
 
-Use `pip` to install mkdocstrings *without support for any languages*:
+The `mkdocstrings` package doesn't provide support for any language: it's just a common base for language handlers.
+It means you likely want to install it with one or more official handlers, using [extras](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras).
+For example, to install it with Python support:
 
 ```bash
-pip install mkdocstrings
+pip install mkdocstrings[python]
 ```
 
-You must install support for specific languages using extras. For example,
-the following installs mkdocstrings with support for Crystal and Python:
+Alternatively, you can directly install the language handlers themselves,
+which depend on `mkdocstrings` anyway:
 
 ```bash
-pip install 'mkdocstrings[crystal,python]'
+pip install mkdocstrings-python
 ```
 
-See the [available language handlers](https://mkdocstrings.github.io/handlers/overview/).
+This will give you more control over the accepted range of versions for the handlers themselves.
+
+See the [official language handlers](https://mkdocstrings.github.io/handlers/overview/).
+
+---
 
 With `conda`:
 
 ```bash
-conda install -c conda-forge mkdocstrings
+conda install -c conda-forge mkdocstrings mkdocstrings-python
 ```
 
 ## Quick usage

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ It means you likely want to install it with one or more official handlers, using
 For example, to install it with Python support:
 
 ```bash
-pip install mkdocstrings[python]
+pip install 'mkdocstrings[python]'
 ```
 
 Alternatively, you can directly install the language handlers themselves,


### PR DESCRIPTION
I just encountered this today and it seems I'm at least the fourth person:

1. https://github.com/mkdocstrings/mkdocstrings/issues/648
2. https://github.com/mkdocstrings/mkdocstrings/issues/647
3. https://github.com/mkdocstrings/mkdocstrings/issues/623

This altered verbiage would have triggered me to correctly install mkdocstrings with support for Python.