### PR TITLE
Add support for authentication in inventory file URLs

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -31,8 +31,8 @@ The YAML block is optional, and contains some configuration options:
   `default_handler` key, or `"python"`.
 - `options`: a dictionary of options passed to the handler's methods responsible both
   for collecting and rendering the documentation. These options can be defined
-  globally (in `mkdocs.yml`, see [Global options](#global-options)), 
-  locally (as described here), or both. 
+  globally (in `mkdocs.yml`, see [Global options](#global-options)),
+  locally (as described here), or both.
 
 !!! example "Example with the Python handler"
     === "docs/my_page.md"
@@ -176,7 +176,7 @@ is possible to link to with `[example][full.path.object1]`, regardless of the cu
 
 ### Cross-references to any Markdown heading
 
-TIP: **Changed in version 0.15.**  
+TIP: **Changed in version 0.15.**
 Linking to any Markdown heading used to be the default, but now opt-in is required.
 
 If you want to link to *any* Markdown heading, not just *mkdocstrings*-inserted items, please
@@ -318,6 +318,18 @@ plugins:
 
 Absolute URLs to cross-referenced items will then be based
 on `https://docs.example.com/version/` instead of `https://cdn.example.com/version/`.
+
+If you need authentication to access the inventory file, you can provide the credentials as environment variables in the URL, either as `username:password`:
+
+```yaml
+- url: https://$MY_USERNAME:$MY_PASSWORD@private.example.com/version/objects.inv
+```
+
+or with token authentication:
+
+```yaml
+- url: https://$TOKEN@private.example.com/version/objects.inv
+```
 
 Reciprocally, *mkdocstrings* also allows to *generate* an inventory file in the Sphinx format.
 It will be enabled by default if the Python handler is used, and generated as `objects.inv` in the final site directory.

--- a/src/mkdocstrings/_cache.py
+++ b/src/mkdocstrings/_cache.py
@@ -4,26 +4,72 @@ import hashlib
 import os
 import urllib.parse
 import urllib.request
-from typing import BinaryIO, Callable
+from typing import BinaryIO, Callable, Union
 
 import click
 import platformdirs
+import regex as re
 
 from mkdocstrings.loggers import get_logger
 
 log = get_logger(__name__)
 
+# Regex pattern for an environment variable
+ENV_VAR_PATTERN = re.compile(r"^\$([A-Za-z_][A-Za-z0-9_]*)$")
+
 
 def download_url_with_gz(url: str) -> bytes:
+    url, auth_header = _extract_auth_from_url(url)
+
     req = urllib.request.Request(  # noqa: S310
         url,
-        headers={"Accept-Encoding": "gzip", "User-Agent": "mkdocstrings/0.15.0"},
+        headers={"Accept-Encoding": "gzip", "User-Agent": "mkdocstrings/0.15.0", **auth_header},
     )
     with urllib.request.urlopen(req) as resp:  # noqa: S310
         content: BinaryIO = resp
         if "gzip" in resp.headers.get("content-encoding", ""):
             content = gzip.GzipFile(fileobj=resp)  # type: ignore[assignment]
         return content.read()
+
+
+def _extract_auth_from_url(url: str) -> tuple[str, dict[str, str]]:
+    """Extracts the username and password from the URL, if present, and returns the URL and the auth header."""
+    parsed_url = urllib.parse.urlparse(url)
+
+    auth_header: dict[str, str] = {}
+    if parsed_url.username:
+        # If the URL contains a username, we assume the user is trying to authenticate
+        auth_header = _create_auth_header(user_env_var=parsed_url.username, pwd_env_var=parsed_url.password)
+        # Remove the auth part from the URL
+        url = parsed_url._replace(netloc=parsed_url.hostname or "").geturl()
+    return url, auth_header
+
+
+def _create_auth_header(user_env_var: str, pwd_env_var: Union[str, None] = None) -> dict[str, str]:
+    """Creates the Authorization header for basic authentication."""
+    user = _get_environment_variable(user_env_var)
+
+    if pwd_env_var is None:
+        # If password is not provided, we assume that the user is using a token
+        log.debug("Using bearer token for authentication")
+        return {"Authorization": f"Bearer {user}"}
+
+    # Else, we assume that the user is using user:password
+    pwd = _get_environment_variable(pwd_env_var)
+    log.debug("Using basic authentication")
+    return {"Authorization": f"Basic {user}:{pwd}"}
+
+
+def _get_environment_variable(env_var: str) -> str:
+    """Extracts the environment variable name from env_var and returns its value."""
+    match = ENV_VAR_PATTERN.match(env_var)
+    if not match:
+        raise ValueError("URL authentication must be specified as environment variables")
+
+    try:
+        return os.environ[match.group(1)]
+    except KeyError as exc:
+        raise ValueError(f"Environment variable '{match.group(1)}' is not set") from exc
 
 
 # This is mostly a copy of https://github.com/mkdocs/mkdocs/blob/master/mkdocs/utils/cache.py

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,81 @@
+"""Tests for the internal mkdocstrings _cache module."""
+
+from __future__ import annotations
+
+import pytest
+
+from mkdocstrings import _cache
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_url"),
+    [
+        ("http://host/path", "http://host/path"),
+        ("http://username:password@host/path", "http://host/path"),
+        ("http://token@host/path", "http://host/path"),
+    ],
+)
+def test_extract_auth_from_url(monkeypatch: pytest.MonkeyPatch, url: str, expected_url: str) -> None:
+    """Test extracting the auth part from the URL."""
+    monkeypatch.setattr(_cache, "_create_auth_header", lambda *args, **kwargs: {})
+    result_url, _result_auth_header = _cache._extract_auth_from_url(url)
+    assert result_url == expected_url
+
+
+def test_create_auth_header_basic_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test creating the Authorization header for basic authentication."""
+    monkeypatch.setenv("MY_USERNAME", "user123")
+    monkeypatch.setenv("MY_PASSWORD", "pass456")
+
+    auth_header = _cache._create_auth_header(user_env_var="$MY_USERNAME", pwd_env_var="$MY_PASSWORD")  # noqa: S106
+    assert auth_header == {"Authorization": "Basic user123:pass456"}
+
+
+def test_create_auth_header_bearer_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test creating the Authorization header for bearer token authentication."""
+    monkeypatch.setenv("MY_TOKEN", "token123")
+
+    auth_header = _cache._create_auth_header(user_env_var="$MY_TOKEN")
+    assert auth_header == {"Authorization": "Bearer token123"}
+
+
+@pytest.mark.parametrize(
+    ("env_var", "value"),
+    [
+        ("$MY_USERNAME", "some_user"),
+    ],
+)
+def test_get_environment_variable_valid(monkeypatch: pytest.MonkeyPatch, env_var: str, value: str) -> None:
+    """Test getting an environment variable."""
+    monkeypatch.setenv(env_var.replace("$", ""), value)
+    result_value = _cache._get_environment_variable(env_var)
+    assert result_value == value
+
+
+def test_get_environment_variable_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that an exception is raised when the environment variable is not set."""
+    env_var = "MY_USERNAME"
+    monkeypatch.delenv(f"{env_var}", raising=False)
+    with pytest.raises(ValueError, match=r"Environment variable .*? is not set"):
+        _cache._get_environment_variable(f"${env_var}")
+
+
+@pytest.mark.parametrize(
+    ("var", "match"),
+    [
+        ("$var", "var"),
+        ("$VAR", "VAR"),
+        ("$_VAR", "_VAR"),
+        ("$VAR123", "VAR123"),
+        ("$VAR123_", "VAR123_"),
+        ("VAR", None),
+        ("$1VAR", None),
+    ],
+)
+def test_env_var_pattern(var: str, match: str | None) -> None:
+    """Test the environment variable regex pattern."""
+    _match = _cache.ENV_VAR_PATTERN.match(var)
+    if _match is None:
+        assert match is _match
+    else:
+        assert _match.group(1) == match


### PR DESCRIPTION
Implement basic and bearer token authentication for downloading private inventory files in mkdocstrings. This allows users to provide credentials via environment variables in the URL. 

Update documentation to reflect these changes and add test cases to ensure functionality.

Closes https://github.com/mkdocstrings/mkdocstrings/issues/707.