### PR TITLE
refactor: Clean up data passed down from plugin to extension and handlers

### DIFF
--- a/config/pytest.ini
+++ b/config/pytest.ini
@@ -12,8 +12,9 @@ filterwarnings =
   error
   # TODO: remove once pytest-xdist 4 is released
   ignore:.*rsyncdir:DeprecationWarning:xdist
-  # TODO: remove once griffe and mkdocstrings-python release new versions
-  ignore:.*`get_logger`:DeprecationWarning:_griffe
-  ignore:.*`name`:DeprecationWarning:_griffe
-  ignore:.*Importing from `griffe:DeprecationWarning:mkdocstrings_handlers
-  ignore:.*`patch_loggers`:DeprecationWarning:_griffe
+  # TODO: remove once mkdocstrings-python releases a new version
+  ignore:.*`handler` argument:DeprecationWarning:mkdocstrings_handlers
+  ignore:.*`mdx` argument:DeprecationWarning:mkdocstrings_handlers
+  ignore:.*`mdx_config` argument:DeprecationWarning:mkdocstrings_handlers
+  ignore:.*`update_env\(md\)` parameter:DeprecationWarning:mkdocstrings
+  ignore:.*`super\(\).update_env\(\)` anymore:DeprecationWarning:mkdocstrings_handlers

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -265,7 +265,7 @@ class BaseHandler:
         """
         yield from ()
 
-    def collect(self, identifier: str, config: MutableMapping[str, Any]) -> CollectorItem:
+    def collect(self, identifier: str, config: Mapping[str, Any]) -> CollectorItem:
         """Collect data given an identifier and user configuration.
 
         In the implementation, you typically call a subprocess that returns JSON, and load that JSON again into

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -587,6 +587,17 @@ class Handlers:
         """
         return config.get("handler", self._default)
 
+    def get_handler_config(self, name: str) -> dict:
+        """Return the global configuration of the given handler.
+
+        Arguments:
+            name: The name of the handler to get the global configuration of.
+
+        Returns:
+            The global configuration of the given handler. It can be an empty dictionary.
+        """
+        return self._handlers_config.get(name, None) or {}
+
     def get_handler(self, name: str, handler_config: dict | None = None) -> BaseHandler:
         """Get a handler thanks to its name.
 


### PR DESCRIPTION
These changes straighten up what arguments are passed to the extension, the `Handlers` class, and the handlers' `get_handler` functions.

Previously there was a lot of redundancy, building and passing mutable dictionaries around.

Now we pass exactly what each class/function needs, as well as the global MkDocs config (renamed "tool config" to decouple ourselves a bit from MkDocs) in case users need it (`get_handler` functions and `update_env` methods, mainly).

These changes bring a few deprecations with relevant messages, as well as a few breaking changes in mkdocstrings' API for which we didn't identify any public use on GitHub.

### Breaking changes

- `mkdocstrings.extension.AutoDocProcessor.__init__(parser)`: *Parameter was removed*
- `mkdocstrings.extension.AutoDocProcessor.__init__(md)`: *Positional parameter was moved*
- `mkdocstrings.extension.AutoDocProcessor.__init__(config)`: *Parameter was removed*
- `mkdocstrings.extension.AutoDocProcessor.__init__(handlers)`: *Parameter kind was changed*: `positional or keyword` -> `keyword-only`
- `mkdocstrings.extension.AutoDocProcessor.__init__(autorefs)`: *Parameter kind was changed*: `positional or keyword` -> `keyword-only`
- `mkdocstrings.extension.MkdocstringsExtension.__init__(config)`: *Parameter was removed*
- `mkdocstrings.extension.MkdocstringsExtension.__init__(handlers)`: *Positional parameter was moved*
- `mkdocstrings.extension.MkdocstringsExtension.__init__(autorefs)`: *Positional parameter was moved*
- `mkdocstrings.handlers.base.Handlers.__init__(config)`: *Parameter was removed*
- `mkdocstrings.handlers.base.Handlers.__init__(theme)`: *Parameter was added as required*
- `mkdocstrings.handlers.base.Handlers.__init__(default)`: *Parameter was added as required*
- `mkdocstrings.handlers.base.Handlers.__init__(inventory_project)`: *Parameter was added as required*
- `mkdocstrings.handlers.base.Handlers.__init__(tool_config)`: *Parameter was added as required*

Again, I could not find any public use of this API on GitHub.