### PR TITLE
fix: Load Sphinx inventories whose dispname spans multiple lines

### DIFF
--- a/config/ruff.toml
+++ b/config/ruff.toml
@@ -43,6 +43,7 @@ ignore = [
     "PLR0913",  # Too many arguments to function call
     "PLR0915",  # Too many statements
     "SLF001", # Private member accessed
+    "S704", # Unsafe use of `markupsafe.Markup`
     "TRY003",  # Avoid specifying long messages outside the exception class
 ]
 

--- a/scripts/insiders.py
+++ b/scripts/insiders.py
@@ -168,6 +168,6 @@ goals = funding_goals(data_source, funding=current_funding)
 ongoing_goals = [goal for goal in goals.values() if not goal.complete]
 unreleased_features = sorted(
     (ft for ft in feature_list(ongoing_goals) if ft.since),
-    key=lambda ft: cast(date, ft.since),
+    key=lambda ft: cast("date", ft.since),
     reverse=True,
 )

--- a/src/mkdocstrings/_internal/handlers/base.py
+++ b/src/mkdocstrings/_internal/handlers/base.py
@@ -17,7 +17,6 @@ from xml.etree.ElementTree import Element, tostring
 
 from jinja2 import Environment, FileSystemLoader
 from markdown import Markdown
-from markdown.extensions.toc import TocTreeprocessor
 from markupsafe import Markup
 from mkdocs.utils.cache import download_and_cache_url
 from mkdocs_autorefs import AutorefsInlineProcessor, BacklinksTreeProcessor
@@ -33,7 +32,6 @@ from mkdocstrings._internal.handlers.rendering import (
 from mkdocstrings._internal.inventory import Inventory
 from mkdocstrings._internal.loggers import get_logger, get_template_logger
 
-
 # YORE: EOL 3.9: Replace block with line 4.
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
@@ -44,6 +42,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, Sequence
 
     from markdown import Extension
+    from markdown.extensions.toc import TocTreeprocessor
     from mkdocs_autorefs import AutorefsHookInterface, Backlink
 
 _logger = get_logger(__name__)
@@ -494,7 +493,7 @@ class BaseHandler:
         el = Element(f"h{heading_level}", attributes)
         el.append(Element("mkdocstrings-placeholder"))
         # Tell the inner 'toc' extension to make its additions if configured so.
-        toc = cast(TocTreeprocessor, self.md.treeprocessors["toc"])
+        toc = cast("TocTreeprocessor", self.md.treeprocessors["toc"])
         if toc.use_anchors:
             toc.add_anchor(el, attributes["id"])
         if toc.use_permalinks:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-import sys
 from textwrap import dedent
 from typing import TYPE_CHECKING
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -11,8 +11,6 @@ from mkdocs.config import load_config
 
 from mkdocstrings import Inventory, InventoryItem
 
-sphinx = pytest.importorskip("sphinx.util.inventory", reason="Sphinx is not installed")
-
 
 @pytest.mark.parametrize(
     "our_inv",
@@ -21,10 +19,13 @@ sphinx = pytest.importorskip("sphinx.util.inventory", reason="Sphinx is not inst
         Inventory([InventoryItem(name="object_path", domain="py", role="obj", uri="page_url")]),
         Inventory([InventoryItem(name="object_path", domain="py", role="obj", uri="page_url#object_path")]),
         Inventory([InventoryItem(name="object_path", domain="py", role="obj", uri="page_url#other_anchor")]),
+        Inventory([InventoryItem(name="o", domain="py", role="obj", uri="u#o", dispname="first line\nsecond line")]),
     ],
 )
 def test_sphinx_load_inventory_file(our_inv: Inventory) -> None:
     """Perform the 'live' inventory load test."""
+    sphinx = pytest.importorskip("sphinx.util.inventory", reason="Sphinx is not installed")
+
     buffer = BytesIO(our_inv.format_sphinx())
     sphinx_inv = sphinx.InventoryFile.load(buffer, "", join)
 
@@ -37,6 +38,8 @@ def test_sphinx_load_inventory_file(our_inv: Inventory) -> None:
 
 def test_sphinx_load_mkdocstrings_inventory_file() -> None:
     """Perform the 'live' inventory load test on mkdocstrings own inventory."""
+    sphinx = pytest.importorskip("sphinx.util.inventory", reason="Sphinx is not installed")
+
     mkdocs_config = load_config()
     mkdocs_config["plugins"].run_event("startup", command="build", dirty=False)
     try:
@@ -53,3 +56,29 @@ def test_sphinx_load_mkdocstrings_inventory_file() -> None:
 
     for item in own_inv.values():
         assert item.name in sphinx_inv[f"{item.domain}:{item.role}"]
+
+
+@pytest.mark.parametrize(
+    "our_inv",
+    [
+        Inventory(),
+        Inventory([InventoryItem(name="object_path", domain="py", role="obj", uri="page_url")]),
+        Inventory([InventoryItem(name="object_path", domain="py", role="obj", uri="page_url#object_path")]),
+        Inventory([InventoryItem(name="object_path", domain="py", role="obj", uri="page_url#other_anchor")]),
+        Inventory([InventoryItem(name="o", domain="py", role="obj", uri="u#o", dispname="first line\nsecond line")]),
+    ],
+)
+def test_mkdocstrings_roundtrip_inventory_file(our_inv: Inventory) -> None:
+    """Save some inventory files, then load them in again."""
+    buffer = BytesIO(our_inv.format_sphinx())
+    round_tripped = Inventory.parse_sphinx(buffer)
+
+    assert our_inv.keys() == round_tripped.keys()
+    for key, value in our_inv.items():
+        round_tripped_item = round_tripped[key]
+        assert round_tripped_item.name == value.name
+        assert round_tripped_item.domain == value.domain
+        assert round_tripped_item.role == value.role
+        assert round_tripped_item.uri == value.uri
+        assert round_tripped_item.priority == value.priority
+        assert round_tripped_item.dispname == value.dispname.splitlines()[0]

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from io import BytesIO
 from os.path import join
 


### PR DESCRIPTION
Hi! I'm Josh, I'm in charge of documentation at [Open Force Field](https://docs.openforcefield.org). We produce a particular kind of mathematical model for computational chemistry. I haven't been using mkdocs/mkdocstrings for long, but I'm enjoying getting to know it, and I'm very excited to write docstrings in markdown!

This is my first contribution here. Thanks for making such clear contributor docs! If you'd rather I do anything another way I'm very happy to fix things. Sorry I haven't raised an issue, but by the time I'd figured out what was going on I basically had the fix written, so it's all here.

## The issue

When a display name in a Sphinx inventory file spans multiple lines, both mkdocstrings and Sphinx simply print the newline character and then the continuation. This is because a display name spanning multiple lines is a rare edge case that was not accounted for in either software. However, while Sphinx discards any inventory lines that do not parse (such as the continuation line), mkdocstrings raises an error, causing the entire inventory file to fail to load.

## Additional context

This continuation line behavior can be seen in the wild in the [OpenEye Toolkits inventory file] and a few Open Force Field [inventory] [files]. These projects' inventories cannot be used with mkdocstrings because of the raised error. You can see this for yourself by uncommenting the relevant lines in OpenFF Pablo's [`mkdocs.yml`], but it might be a pain to collect the dependencies unless you're familiar with Conda (environment file is in `devtools/conda-envs/docs_env.yaml`).

[`mkdocs.yml`]: https://github.com/openforcefield/openff-pablo/blob/177a0e94bbbb74d90e3a80ac08cad998e6b3ac15/docs/mkdocs.yml#L139-L148
[OpenEye Toolkits inventory file]: https://docs.eyesopen.com/toolkits/python/objects.inv
[inventory]:  https://docs.openforcefield.org/projects/toolkit/en/stable/objects.inv
[files]: https://docs.openforcefield.org/projects/bespokefit/en/stable/objects.inv

Note that in Sphinx, these inventory files are read successfully, but the continuation lines are discarded, truncating the display name. In theory, a continuation line that by chance did parse correctly would be interpreted by both packages as a new inventory item.

## Changes in this PR

This PR appends the continuation line to the previous inventory item display name when it fails to parse. This allows these inventory files to be loaded while preserving the original display name. Note that the theoretical continuation line that parses by chance is not addressed. Round-trip tests and additional Sphinx tests are added to check the new behavior. I've run these tests locally with Sphinx added to the dependencies and they do actually succeed, and I've also confirmed that they fail without the new code to confirm the tests are doing something.

I also found that `make format` and `make check` introduced several formatting changes and new lint failures outside the files I changed; I determined that they were due to the recent new version of Ruff and corrected them in a separate commit within this PR. One judgement I made there that deserves particular review is that a [new Ruff lint] was triggered, apparently over-eagerly; applying the suggested fix where it made sense caused the tests to fail. I therefore set the lint to be ignored. There are some more details in the commit message. Happy to tweak this (and everything else), but it seemed like the existing code was using `markupsafe.Markup` as intended to declare that a certain bit of dynamically generated markup was correct, and the lint was applying too strict a standard.

[new Ruff lint]: https://docs.astral.sh/ruff/rules/unsafe-markup-use/

## Other stuff

Thanks for all your work on mkdocstrings!