### PR TITLE
Increase minimum version of python-legacy handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 
 [project.optional-dependencies]
 crystal = ["mkdocstrings-crystal>=0.3.4"]
-python-legacy = ["mkdocstrings-python-legacy>=0.2.1"]
+python-legacy = ["mkdocstrings-python-legacy>=0.2.5"]
 python = ["mkdocstrings-python>=1.16.2"]
 
 [project.urls]


### PR DESCRIPTION
Just updating `mkdocstrings` without raising the `mkdocstrings-python-legacy` causes lots of deprecation warnings when the latter is still at `0.2.4`.