### PR TITLE
doc: Add links to MATLAB handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Come have a chat or ask questions on our [Gitter channel](https://gitter.im/mkdo
   [C](https://mkdocstrings.github.io/c/),
   [Crystal](https://mkdocstrings.github.io/crystal/),
   [Python](https://mkdocstrings.github.io/python/),
+  [MATLAB](https://watermarkhu.nl/mkdocstrings-matlab/),
   [TypeScript](https://mkdocstrings.github.io/typescript/), and
   [VBA](https://pypi.org/project/mkdocstrings-vba/) languages,
   as well as for [shell scripts/libraries](https://mkdocstrings.github.io/shell/).

--- a/docs/usage/handlers.md
+++ b/docs/usage/handlers.md
@@ -8,6 +8,7 @@ A handler is what makes it possible to collect and render documentation for a pa
 - [Crystal](https://mkdocstrings.github.io/crystal/){ .external }
 - [Python](https://mkdocstrings.github.io/python/){ .external }
 - [Python (Legacy)](https://mkdocstrings.github.io/python-legacy/){ .external }
+- [MATLAB](https://watermarkhu.nl/mkdocstrings-matlab/){ .external }
 - [Shell](https://mkdocstrings.github.io/shell/){ .external }
 - [TypeScript](https://mkdocstrings.github.io/typescript/){ .external }
 - [VBA](https://pypi.org/project/mkdocstrings-vba/){ .external }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
     - Crystal: https://mkdocstrings.github.io/crystal/
     - Python: https://mkdocstrings.github.io/python/
     - Python (Legacy): https://mkdocstrings.github.io/python-legacy/
+    - MATLAB: https://watermarkhu.nl/mkdocstrings-matlab/
     - Shell: https://mkdocstrings.github.io/shell/
     - TypeScript: https://mkdocstrings.github.io/typescript/
     - VBA: https://pypi.org/project/mkdocstrings-vba


### PR DESCRIPTION
Add links to the MATLAB handler: http://watermarkhu.nl/mkdocstrings-matlab/

@pawamoy I figured it's time :)