### PR TITLE
fix: Create default ssl context and discard before downloading inventories

### DIFF
--- a/src/mkdocstrings/_internal/extension.py
+++ b/src/mkdocstrings/_internal/extension.py
@@ -125,7 +125,7 @@ class AutoDocProcessor(BlockProcessor):
             heading_level = match["heading"].count("#")
             _logger.debug("Matched '::: %s'", identifier)
 
-            html, handler, data = self._process_block(identifier, block, heading_level)
+            html, handler, _data = self._process_block(identifier, block, heading_level)
             el = Element("div", {"class": "mkdocstrings"})
             # The final HTML is inserted as opaque to subsequent processing, and only revealed at the end.
             el.text = self.md.htmlStash.store(html)

--- a/src/mkdocstrings/_internal/extension.py
+++ b/src/mkdocstrings/_internal/extension.py
@@ -125,7 +125,7 @@ class AutoDocProcessor(BlockProcessor):
             heading_level = match["heading"].count("#")
             _logger.debug("Matched '::: %s'", identifier)
 
-            html, handler, _data = self._process_block(identifier, block, heading_level)
+            html, handler, data = self._process_block(identifier, block, heading_level)
             el = Element("div", {"class": "mkdocstrings"})
             # The final HTML is inserted as opaque to subsequent processing, and only revealed at the end.
             el.text = self.md.htmlStash.store(html)

--- a/src/mkdocstrings/_internal/handlers/base.py
+++ b/src/mkdocstrings/_internal/handlers/base.py
@@ -8,6 +8,7 @@ import datetime
 import importlib
 import inspect
 import sys
+import ssl
 from concurrent import futures
 from io import BytesIO
 from pathlib import Path
@@ -753,6 +754,9 @@ class Handlers:
             to_download.extend((handler, url, conf) for url, conf in inv_configs)
 
         if to_download:
+            # NOTE: Simply creating default context somehow fixes
+            # https://github.com/mkdocstrings/mkdocstrings/issues/796
+            _ = ssl.create_default_context()
             thread_pool = futures.ThreadPoolExecutor(4)
             for handler, url, conf in to_download:
                 _logger.debug("Downloading inventory from %s", url)

--- a/src/mkdocstrings/_internal/handlers/base.py
+++ b/src/mkdocstrings/_internal/handlers/base.py
@@ -754,9 +754,11 @@ class Handlers:
             to_download.extend((handler, url, conf) for url, conf in inv_configs)
 
         if to_download:
-            # NOTE: Simply creating default context somehow fixes
-            # https://github.com/mkdocstrings/mkdocstrings/issues/796
+            # YORE: EOL 3.12: Remove block.
+            # NOTE: Create context in main thread to fix issue
+            # https://github.com/mkdocstrings/mkdocstrings/issues/796.
             _ = ssl.create_default_context()
+
             thread_pool = futures.ThreadPoolExecutor(4)
             for handler, url, conf in to_download:
                 _logger.debug("Downloading inventory from %s", url)

--- a/src/mkdocstrings/_internal/handlers/base.py
+++ b/src/mkdocstrings/_internal/handlers/base.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 import datetime
 import importlib
 import inspect
-import sys
 import ssl
+import sys
 from concurrent import futures
 from io import BytesIO
 from pathlib import Path


### PR DESCRIPTION
100% disclosure: I don't know why this works.

Resolves #796
