### PR TITLE
fix: add timeout to urlopen

### DIFF
--- a/src/mkdocstrings/_internal/download.py
+++ b/src/mkdocstrings/_internal/download.py
@@ -19,6 +19,9 @@ _logger = get_logger("mkdocstrings")
 # Regex pattern for an environment variable in the form ${ENV_VAR}.
 _ENV_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
+# Timeout in seconds for downloading.
+_TIMEOUT = 10
+
 
 def _download_url_with_gz(url: str) -> bytes:
     url, auth_header = _extract_auth_from_url(url)
@@ -27,7 +30,7 @@ def _download_url_with_gz(url: str) -> bytes:
         url,
         headers={"Accept-Encoding": "gzip", "User-Agent": "mkdocstrings/0.15.0", **auth_header},
     )
-    with urllib.request.urlopen(req) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:  # noqa: S310
         content: BinaryIO = resp
         if "gzip" in resp.headers.get("content-encoding", ""):
             content = gzip.GzipFile(fileobj=resp)  # ty: ignore[invalid-assignment]


### PR DESCRIPTION
This prevents _download_url_with_gz from appearing to be hanging if e.g. the URL is blackholed. Without an explicit timeout, `urlopen.request` uses the global default timeout (`socket.getdefaulttimeout()`), which is `None` by default. This then leaves it up to the OS to decide how long to wait before giving up, which is typically too long for this purpose (e.g. ~127 seconds on Linux).

### For reviewers
<!-- Help reviewers by letting them know whether AI was used to create this PR. -->

- [x] I did not use AI
- [ ] I used AI and thoroughly reviewed every code/docs change

### Description of the change
<!-- Quick sentence for small changes, longer description for more impacting changes. -->

Use an explicit 10 seconds timeout.

### Relevant resources
<!-- Link to any relevant GitHub issue, PR or discussion, section in online docs, etc. -->

Closes #819 
